### PR TITLE
fix: characters card's width

### DIFF
--- a/style.css
+++ b/style.css
@@ -716,11 +716,10 @@ button#scrolltopBtn {
 
 /* Position the front and back side */
 .flip-card-front, .flip-card-back {
-  margin: 70px 0;
   box-shadow: 0 5px 24px 0 rgb(0 0 0 / 80%);
   border-radius: 29px;
   position: absolute;
-  min-width: 250px;
+  min-width: 400px;
   height: 400px;
   -webkit-backface-visibility: hidden; /* Safari */
   backface-visibility: hidden;


### PR DESCRIPTION
I've fixed the width of the character's card on the home page as some of them are not occupying the card background ideally. I am attaching a screenshot for your reference.

Fixes #979 

![fix-narutoCard](https://user-images.githubusercontent.com/72399705/197981204-cec570e3-235b-421d-b9bf-e70dcf5cf64d.png)
