### PR TITLE
fix: footer's position

### DIFF
--- a/index.html
+++ b/index.html
@@ -2358,7 +2358,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
             <!--[Kisame Hoshigaki] card end-->
 
                      <!-- Rasa card start-->
@@ -2374,7 +2373,6 @@
                         </div>
                     </div>
                 </div>
-                </div>
                 <!-- Rasa card end-->
                 
             <!-- [Gold and Silver Brothers] card start-->
@@ -2389,7 +2387,6 @@
                         <p>They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
    </div>
                     </div>
-                </div>
                 </div>
                 <!--[Kisame Hoshigaki] card end-->
 
@@ -2416,7 +2413,6 @@
                             </p>
                         </div>
                     </div>
-                </div>
                 </div>
                 <!--[Gold and Silver Brothers] card end-->
 


### PR DESCRIPTION
I've fixed the footer position at the end of the homepage. Attaching a screenshot for reference.

Fixes: #981 
![fix-footer](https://user-images.githubusercontent.com/72399705/197997662-57208aa2-a454-4040-ae87-4a84ada27bea.png)

Please merge my pull request.