### PR TITLE
Fix the html tags wrong closed that broke the content with the flip-cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2358,7 +2358,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
             <!--[Kisame Hoshigaki] card end-->
 
                      <!-- Rasa card start-->
@@ -2374,7 +2373,6 @@
                         </div>
                     </div>
                 </div>
-                </div>
                 <!-- Rasa card end-->
                 
             <!-- [Gold and Silver Brothers] card start-->
@@ -2387,7 +2385,6 @@
                     <div class="flip-card-back">
                         <p class="card-text">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
                         <p>They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
-   </div>
                     </div>
                 </div>
                 </div>
@@ -2417,7 +2414,6 @@
                         </div>
                     </div>
                 </div>
-                </div>
                 <!--[Gold and Silver Brothers] card end-->
 
 
@@ -2440,7 +2436,6 @@
                     </div>
                 </div>
 
-               </div>
 	            <!--[Asura Path of Pain] card end-->
           <!-- [A (First Raikage)] card start-->
               <div class="flip-card">
@@ -2502,6 +2497,7 @@
             <!--[A (Third Raikage)] card end-->
 
 
+            </div>
         </main>
         <audio src="./sound/naruto.mp3"></audio>
 


### PR DESCRIPTION
Fix issue #983

- [fix(html): wrong html tags break the content with flip-cards](https://github.com/vikhyatsingh123/Naruto-Shippuden/pull/984/commits/8c617f0ed86b8bf9052ec4e5b54a7b318f186133)
There are too many unnecessary `<div>` tags that are causing the `flip-cards` to remain outside the `div#cont.container`.
![image](https://user-images.githubusercontent.com/14045148/198007598-1130ec10-4d4f-4671-9301-72a203f579b3.png)
![image](https://user-images.githubusercontent.com/14045148/198007627-763156b5-35a1-49c0-91ba-e93085761d7a.png)
![image](https://user-images.githubusercontent.com/14045148/198014371-157bdbaf-5d4a-4e41-8838-08cc462300c7.png)