### PR TITLE
hotfix/986-987-flip-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,20 @@ Not everyone is aware of every tool present in the world no matter how easy or c
 
                 <!-- [character name] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
-                            <h2 class="card-title">[name of character]</h2>
-                            <img class="img_card" src=[image-link] alt=[name of character] height="300px" width="300px">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
+                            <h2 class="flip-card__title">
+                                [name of character]
+                            </h2>
+                            <img class="flip-card__image" src=[image-link] alt=[name of character] height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">[Main description about character]</p>
-                            <p class="card-text">[some more description about character]</p>
+                        <div class="flip-card__back">
+                            <p class="flip-card__text flip-card__text--main">
+                                [Main description about character]
+                            </p>
+                            <p class="flip-card__text">
+                                [some more description about character]
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Not everyone is aware of every tool present in the world no matter how easy or c
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">[name of character]</h2>
-                            <img src=[image-link] alt=[name of character] height="300px" width="300px" class="img_card">
+                            <img class="img_card" src=[image-link] alt=[name of character] height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">[Main description about character]</p>

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Not everyone is aware of every tool present in the world no matter how easy or c
                             <img src=[image-link] alt=[name of character] height="300px" width="300px" class="img_card">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">[Main description about character]</p>
+                            <p class="card-text card-text--main">[Main description about character]</p>
                             <p class="card-text">[some more description about character]</p>
                         </div>
                     </div>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Not everyone is aware of every tool present in the world no matter how easy or c
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">[Main description about character]</p>
-                            <p>[some more description about character]</p>
+                            <p class="card-text">[some more description about character]</p>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -110,16 +110,16 @@
                 <!--[Naruto] card start -->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Naruto Uzumaki</h2>
-                            <img class="img_card" src="./Images/naruto.png" alt="naruto" height="330px" width="300px">
+                            <img class="flip-card__image" src="./Images/naruto.png" alt="naruto" height="330px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Naruto Uzumaki is the main protagonist in the popular manga and anime
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Naruto Uzumaki is the main protagonist in the popular manga and anime
                                 series Naruto. He is a cheerful, hyperactive, strong-willed, and occasionally
                                 simple-minded young shinobi from the village of Konoha (or Leaf Village).</p>
-                            <p class="card-text">Since Naruto has the Nine Tails Fox sealed inside him, he is able to use the Fox's
+                            <p class="filp-card__text">Since Naruto has the Nine Tails Fox sealed inside him, he is able to use the Fox's
                                 chakra, which is much greater than the average human. Initially Naruto and the Fox hated
                                 each other, and would rarely grant Naruto his power
                                 unless they were going to die. Eventually, they become friends, and Naruto then refers
@@ -133,13 +133,13 @@
                 <!--[Sasuke Uchiha] card start-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Sasuke Uchiha</h2>
-                            <img class="img_card" src="./Images/Sasuke.png" alt="Sasuke Uchiha" height="350px" width="250px">
+                            <img class="flip-card__image" src="./Images/Sasuke.png" alt="Sasuke Uchiha" height="350px" width="250px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Sasuke Uchiha (うちはサスケ, Uchiha Sasuke) is one of the last surviving
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Sasuke Uchiha (うちはサスケ, Uchiha Sasuke) is one of the last surviving
                                 members of Konohagakure's Uchiha clan. After his older brother, Itachi, slaughtered
                                 their clan, Sasuke made it his mission in life to avenge them by killing
                                 Itachi. He is added to Team 7 upon becoming a ninja and, through competition with his
@@ -153,22 +153,21 @@
 
                 <!-- [Suigetsu] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Suigetsu</h2>
-                            <img class="img_card" src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px"
-                               >
+                            <img class="flip-card__image" src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px">
 
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">
+                            <p class="filp-card__text filp-card__text--main">
                                 Suigetsu was a member of Sasuke's renegade group consisting of himself, Suigetsu, Karin,
                                 and Jugo. Of the quartet, Suigetsu was the self-styled comedian. He had plenty of
                                 sarcastic lines and made every effort he could to get under Karin's skin.
 
                             </p>
-                            <p class="card-text">The above line was especially funny coming from Suigetsu, as the audience got the
+                            <p class="filp-card__text">The above line was especially funny coming from Suigetsu, as the audience got the
                                 distinct impression that he probably wasn't a true believer in Sasuke's dream. It was
                                 even funnier in the moment, as he made a decisive gesture with a spoon he was using at
                                 the time.</p>
@@ -181,13 +180,13 @@
 
                 <!-- [Sai] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Sai Yamanaka</h2>
-                            <img class="img_card" src="./Images/Sai_Infobox.png" alt="Sai" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Sai_Infobox.png" alt="Sai" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Sai Yamanaka (山中サイ, Yamanaka Sai) is the Anbu Chief of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Sai Yamanaka (山中サイ, Yamanaka Sai) is the Anbu Chief of
                                 Konohagakure's Yamanaka clan. Prior to this, he was a Root member.
                                 As per standard Root training, Sai was conditioned to remove all emotions and as such,
                                 had difficulty connecting with others. When he is added to Team Kakashi as a replacement
@@ -204,14 +203,14 @@
 
                 <!-- [Anko Mitarashi] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Anko Mitarashi</h2>
-                            <img class="img_card" src="./Images/anko.jpg" alt="Anko Mitarashi" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/anko.jpg" alt="Anko Mitarashi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">The proctor of the survival leg of the Chuunin exams, she goes through
+                            <p class="filp-card__text filp-card__text--main">The proctor of the survival leg of the Chuunin exams, she goes through
                                 her enemies like a blazing inferno. She was once tutored by Orochimaru, but was
                                 abandoned by him when she refused to follow his evil path.
                                 Anko Mitarashi is a Jonin of the Hidden Leaf Village. She was a proctor of the survival
@@ -227,17 +226,17 @@
 
                 <!-- [Chiriku] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Chiriku</h2>
-                            <img class="img_card" src="./Images/chiriku.jpg" alt="Chiriku" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/chiriku.jpg" alt="Chiriku" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Chiriku is a Fire Temple monk, formerly a member of the “12 Guardian
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Chiriku is a Fire Temple monk, formerly a member of the “12 Guardian
                                 Ninjas” of the Lord of the Fire Land. There he will meet Asuma Sarutobi, son of the
                                 third Hokage. Their mission was to escort and protect the Daimyo of the Land of
                                 Fire.</p>
-                            <p class="card-text">Today he lives in the Temple of Fire with his disciples. He took under his wing a young
+                            <p class="filp-card__text">Today he lives in the Temple of Fire with his disciples. He took under his wing a young
                                 man named Sora, the son of one of the 12 deceased guardian ninjas. His head having been
                                 put on a price of 30 million ryos, he was assassinated by Kakuzu and Hidan during a
                                 fight at the Fire temple. After this clash, the Fire Temple was destroyed. Hidan and
@@ -250,13 +249,13 @@
 
                 <!-- [ten tails] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Ten Tails - Juubi</h2>
-                            <img class="img_card" src="./Images/ten tails.jpeg" alt="Ten Tails" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/ten tails.jpeg" alt="Ten Tails" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">This Ten-Tails (十尾, Jūbi) is the combined form of Kaguya Ōtsutsuki and
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">This Ten-Tails (十尾, Jūbi) is the combined form of Kaguya Ōtsutsuki and
                                 the God Tree, created to reclaim the chakra inherited by her sons, Hagoromo and Hamura.
                                 It is regarded as the progenitor of chakra, and is tied to the legend of the Sage of Six
                                 Paths and the birth of shinobi. To end the beast's rampage, the Sage became the
@@ -271,14 +270,14 @@
 
                 <!-- [Eight Tails] card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Eight Tails - Gyuki</h2>
-                            <img class="img_card" src="./Images/Gyuki-Eight-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
+                            <img class="flip-card__image" src="./Images/Gyuki-Eight-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Gyuki was sold to the Hidden Cloud village along with Matatabi, but the
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Gyuki was sold to the Hidden Cloud village along with Matatabi, but the
                                 nation struggled to find a Jinchuriki who could control it. One of these was Blue B, the
                                 nephew of the Third Raikage, but after Gyuki went on a rampage, the Raikage was
                                 forced to seal him away, causing his nephew's tragic death. Gyuki was ultimately sealed
@@ -294,14 +293,14 @@
 
                 <!-- [Seven Tails] card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Seven-Tails - Chomei</h2>
-                            <img class="img_card" src="./Images/Chomei-Seven-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
+                            <img class="flip-card__image" src="./Images/Chomei-Seven-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Chomei was formerly sealed within Fu, a female ninja from the Hidden
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Chomei was formerly sealed within Fu, a female ninja from the Hidden
                                 Waterfall, after being sold to the village by Hashirama. This was unusual, since the
                                 Waterfall isn't one of Naruto's five major nations, but were considered powerful enough
                                 to be included in the arrangement. Naruto flashbacks show each of the tailed beasts as
@@ -317,18 +316,18 @@
 
                 <!-- [Asura] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Asura</h2>
-                            <img class="img_card" src="./Images/Asura.png" alt="Asura" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Asura.png" alt="Asura" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Asura Ōtsutsuki (大筒木アシュラ, Ōtsutsuki Ashura) was the younger son of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Asura Ōtsutsuki (大筒木アシュラ, Ōtsutsuki Ashura) was the younger son of
                                 Hagoromo Ōtsutsuki. Though not the obvious choice to most, he would go on to inherit his
                                 father's teachings, and as a result, would have to clash bitterly against his elder
                                 brother Indra. Asura is also credited with being the progenitor of both the Senju and
                                 Uzumaki clans.</p>
-                            <p class="card-text">With the power entrusted to him by his father, Asura gained access to the Six Paths
+                            <p class="filp-card__text">With the power entrusted to him by his father, Asura gained access to the Six Paths
                                 Senjutsu, allowing him to augment himself and his various techniques. In this state, he
                                 could fly and manifest a giant three-faced, six-armed avatar, Six Paths: Kunitsukami.
                             </p>
@@ -339,15 +338,15 @@
 
                 <!-- [Inuzuka Hana] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Inuzuka Hana</h2>
-                            <img class="img_card" src="./Images/inuzuka_hana.jpg" alt="Inuzuka Hana" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/inuzuka_hana.jpg" alt="Inuzuka Hana" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hana is a kunoichi from Konoha village. She is Kiba's sister and
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hana is a kunoichi from Konoha village. She is Kiba's sister and
                                 Tsume's daughter</p>
-                            <p class="card-text">Hana also specializes in animal medicine: she is a veterinarian. His companions are 3 dog
+                            <p class="filp-card__text">Hana also specializes in animal medicine: she is a veterinarian. His companions are 3 dog
                                 brothers: Les Trois Frères Haimaru.</p>
                         </div>
                     </div>
@@ -355,18 +354,18 @@
 
                 <!-- Izumi Uchiha card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Izumi Uchiha </h2>
-                            <img class="img_card" src="./Images/Izumi_Uchiha.jpg" alt="Izumi Uchiha" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/Izumi_Uchiha.jpg" alt="Izumi Uchiha" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Izumi was the daughter of Hazuki Uchiha. Unlike her mother, Izumi's
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Izumi was the daughter of Hazuki Uchiha. Unlike her mother, Izumi's
                                 father was not an Uchiha.During the Nine-Tailed Demon Fox's Attack, her father died
                                 while protecting her.From the grief brought on by his death, as well as feelings of
                                 guilt that he would not have died had Izumi been stronger,Izumi eventually awakened her
                                 Sharingan. She and her mother afterwards rejoined the Uchiha clan.</p>
-                            <p class="card-text">Izumi enrolled in Konoha's Academy a few years later.Like other girls her age, Izumi
+                            <p class="filp-card__text">Izumi enrolled in Konoha's Academy a few years later.Like other girls her age, Izumi
                                 developed a crush on Itachi Uchiha, a boy in the class next to hers.As such, she tried
                                 to talk with him during school breaks, walk home with him after lessons, and defend him
                                 from their peers' criticism. Itachi initially took the same disinterest in Izumi that he
@@ -380,15 +379,15 @@
 
                 <!--Fūka card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Fūka</h2>
-                            <img class="img_card" src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
                                 and kill them with an Execution by Kiss.</p>
-                            <p class="card-text">She would further speed up the process by giving her targets a choice between a French or
+                            <p class="filp-card__text">She would further speed up the process by giving her targets a choice between a French or
                                 traditional kiss. Her most preferable victims were those with a natural affinity for
                                 wind chakra. She took great pride in her appearance and would become infuriated when any
                                 harm came to her physical being, especially her hair, the very casing of her soul.
@@ -402,16 +401,16 @@
 
                 <!-- Rôshi Card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Rôshi</h2>
-                            <img class="img_card" src="./Images/roshi.jpg" alt="Rôshi" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/roshi.jpg" alt="Rôshi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Rôshi was the last Jinchûriki of Yonbi, the 4-tailed demon. He was
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Rôshi was the last Jinchûriki of Yonbi, the 4-tailed demon. He was
                                 killed by Kisame Hoshigaki, a former member of the Akatsuki, who aimed to reunite all
                                 the Biju.</p>
-                            <p class="card-text">Rôshi will be resurrected later during the Fourth Great Ninja War by Kabuto Yakushi. He
+                            <p class="filp-card__text">Rôshi will be resurrected later during the Fourth Great Ninja War by Kabuto Yakushi. He
                                 will fight Bee and Naruto.</p>
                         </div>
                     </div>
@@ -420,19 +419,19 @@
 
                 <!-- [Suigetsu] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Suigetsu</h2>
 
-                            <img class="img_card" src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">
                                 Suigetsu was a member of Sasuke's renegade group consisting of himself, Suigetsu, Karin,
                                 and Jugo. Of the quartet, Suigetsu was the self-styled comedian. He had plenty of
                                 sarcastic lines and made every effort he could to get under Karin's skin.
                             </p>
-                            <p class="card-text">The above line was especially funny coming from Suigetsu, as the audience got the
+                            <p class="filp-card__text">The above line was especially funny coming from Suigetsu, as the audience got the
                                 distinct impression that he probably wasn't a true believer in Sasuke's dream. It was
                                 even funnier in the moment, as he made a decisive gesture with a spoon he was using at
                                 the time.</p>
@@ -443,14 +442,14 @@
 
                 <!-- [Boruto] card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Boruto Uzumaki</h2>
 
-                            <img class="img_card" src="./Images/boruto.jpg" alt="boruto" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/boruto.jpg" alt="boruto" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Boruto Uzumaki (うずまきボルト, Uzumaki Boruto) is a shinobi from
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Boruto Uzumaki (うずまきボルト, Uzumaki Boruto) is a shinobi from
                                 Konohagakure's Uzumaki Clan and a direct descendant of the Hyūga clan through his
                                 mother. Initially nonchalant in his duties as a member of Team 7 and resentful of his
                                 father and the office of Hokage because it left him with no time for his family; Boruto
@@ -464,13 +463,13 @@
 
                 <!-- [Madara] card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Uchiha Madara</h2>
-                            <img class="img_card" src="./Images/madara.jpg" alt="boruto" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/madara.jpg" alt="boruto" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">
                                 Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the Uchiha clan.
                                 He founded Konohagakure alongside his childhood friend and rival, Hashirama Senju, with
                                 the intention of beginning an era of peace.
@@ -490,13 +489,13 @@
 
                 <!-- [Ebisu] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Ebisu</h2>
-                            <img class="img_card" src="./Images/Ebisu.png" alt=Ebisu height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Ebisu.png" alt=Ebisu height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Specializes in the private training of Ninja, and is
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Specializes in the private training of Ninja, and is
                                 often referred to as being a closet pervert. He is one of the sensei who's trained
                                 Konohamaru.</p>
                         </div>
@@ -506,16 +505,16 @@
 
                 <!-- Yukimaru card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Yukimaru </h2>
 
-                            <img class="img_card" src="./Images/yukimaru.png" alt="Haku" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/yukimaru.png" alt="Haku" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Yukimaru is a young orphan who became one of Orochimaru's test
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Yukimaru is a young orphan who became one of Orochimaru's test
                                 subjects, due to his ability to partially control the Three-Tails.</p>
-                            <p class="card-text">Yukimaru lived with his mother in a village that was attacked by Orochimaru's followers
+                            <p class="filp-card__text">Yukimaru lived with his mother in a village that was attacked by Orochimaru's followers
                                 when Yukimaru was a child.</p>
                         </div>
                     </div>
@@ -525,17 +524,17 @@
 
                 <!-- Yamato card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Yamato</h2>
-                            <img class="img_card" src="./Images/Yamato.png" alt=Yamato height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Yamato.png" alt=Yamato height="300px" width="300px">
 
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Yamato is a very discreet, cautious, careful and well prepared person.
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Yamato is a very discreet, cautious, careful and well prepared person.
                                 He projects a calm, stoic demeanour in stressful situations. He takes his missions very
                                 seriously, even insisting on being referred to by whatever his current codename</p>
-                            <p class="card-text">Yamato is one of the main supporting characters in the Naruto anime/manga series and the
+                            <p class="filp-card__text">Yamato is one of the main supporting characters in the Naruto anime/manga series and the
                                 Boruto: Naruto Next Generations anime/manga series. He is an ANBU in the service of
                                 Konohagakure. Because of his unique jutsu, he is added to Team Kakashi as a temporary
                                 for Kakashi Hatake. Though Kakashi eventually returns to the team, Yamato stays on to
@@ -546,13 +545,13 @@
 
                 <!-- [Hanabi Hyuga] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hanabi Hyuga</h2>
-                            <img class="img_card" src="./Images/Hanabi-Hyuga.webp" alt="Hanabi Hyuga" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/Hanabi-Hyuga.webp" alt="Hanabi Hyuga" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hanabi is the younger sister of Hinata. She plays an important role in
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hanabi is the younger sister of Hinata. She plays an important role in
                                 The Last: Naruto the Movie. Her father is Hiashi Hyuga and is auntie to Hinata's
                                 children, Boruto and Himawari. Her cousin is Neji Hyuga.
                                 Naruto Uzumaki is her brother-in-law.</p>
@@ -563,13 +562,13 @@
 
                 <!-- [Tsunade] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Tsunade</h2>
-                            <img class="img_card" src="Images/Tsunade.jpg" alt=Tsunade height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/Tsunade.jpg" alt=Tsunade height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Tsunade is a kunoichi from the Hidden Leaf Village and posses
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Tsunade is a kunoichi from the Hidden Leaf Village and posses
                                 Monstrous physical strength, extremely advanced healing and regenerative techniques,
                                 physician/surgeon
                                 level of knowledge of the human body and great Chakra control. At once formed part of
@@ -579,7 +578,7 @@
                                 has become the Fifth Hokage of The Hidden Leaf Village. Her grandparents are revealed to
                                 be Hashirama
                                 Senju and Mito Uzumaki.</p>
-                            <p class="card-text">Tsunade's trademark ability is her inhuman strength, which is derived from her
+                            <p class="filp-card__text">Tsunade's trademark ability is her inhuman strength, which is derived from her
                                 excellent chakra control. By storing chakra and releasing it at the point of contact,
                                 she can enhance her strength to the point where she can break through boulders her bare
                                 hands. She is also an extremely talented Medical-nin, and can heal wounds that most
@@ -599,14 +598,14 @@
 
                 <!-- [Jirobo] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Jirobo</h2>
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330799-jirobo.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330799-jirobo.jpg"
                                 alt=Kawaki height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">A ninja from The Hidden Sound Village and member of The Sound Five.he
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">A ninja from The Hidden Sound Village and member of The Sound Five.he
                                 was the physically strongest member of the Sound Four, but the weakest overall.
                                 According to the other members of the group, nevertheless, he was a formidable opponent.
                                 Furthermore, Shikamaru stated that Jirōbō's prowess was at jōnin-level. In the anime,
@@ -618,15 +617,15 @@
 
                 <!-- [Hanare] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hanare</h2>
-                            <img class="img_card" src="https://qph.fs.quoracdn.net/main-qimg-85fae3ac8ec01ad91d4a5304cf3a2b1a"
+                            <img class="flip-card__image" src="https://qph.fs.quoracdn.net/main-qimg-85fae3ac8ec01ad91d4a5304cf3a2b1a"
                                 alt="Hanare" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hanare (ハナレ, Hanare) is a kunoichi from the Jōmae Village. </p>
-                            <p class="card-text">As a young child, Hanare was said to be very lonely since she had never known her family
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hanare (ハナレ, Hanare) is a kunoichi from the Jōmae Village. </p>
+                            <p class="filp-card__text">As a young child, Hanare was said to be very lonely since she had never known her family
                                 or seen
                                 her own village. She was trained from an early age in the art of espionage. One day, she
                                 was
@@ -652,15 +651,15 @@
 
                 <!--[Fūka] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Fūka</h2>
-                            <img class="img_card" src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
                                 and kill them with an Execution by Kiss.</p>
-                            <p class="card-text">She would further speed up the process by giving her targets a choice between a French or
+                            <p class="filp-card__text">She would further speed up the process by giving her targets a choice between a French or
                                 traditional kiss. Her most preferable victims were those with a natural affinity for
                                 wind chakra. She took great pride in her appearance and would become infuriated when any
                                 harm came to her physical being, especially her hair, the very casing of her soul.
@@ -674,16 +673,16 @@
 
                 <!-- Mizuki card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Mizuki</h2>
-                            <img class="img_card" src="Images/Mizuki.png" alt="Mizuki" height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/Mizuki.png" alt="Mizuki" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The first-ever person whom Naruto faced in a battle in order to know
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The first-ever person whom Naruto faced in a battle in order to know
                                 his power and also get to know about his own ninja way. He thrashed him in the battle
                                 against him while saving Iruka Umino his sensei in his elementary Training Academy</p>
-                            <p class="card-text"> Mizuki duped Naruto Uzumaki into stealing Konoha's Scroll of Seals for him. Originally,
+                            <p class="filp-card__text"> Mizuki duped Naruto Uzumaki into stealing Konoha's Scroll of Seals for him. Originally,
                                 Mizuki had the plan set up to have Naruto as a scapegoat and kill him to hide the truth
                                 of his deception and secretly leave the village with the scroll in his possession.
                                 However, Mizuki's plan is derailed when Iruka found Naruto first and decided to reveal
@@ -698,17 +697,17 @@
 
                 <!-- The Demon Brothers card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">The Demon Brothers</h2>
-                            <img class="img_card" src="Images/Naruto-Demon-Brothers.jpg" alt=[name of character] height="300px"
+                            <img class="flip-card__image" src="Images/Naruto-Demon-Brothers.jpg" alt=[name of character] height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Naruto's first battle against non-Konoha ninja happened at the start of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Naruto's first battle against non-Konoha ninja happened at the start of
                                 the Land of Waves Escort Mission arc. Two allies of Zabuza waited outside of Konoha in
                                 order to ambush Tazuna, who was being escorted by Team 7.</p>
-                            <p class="card-text">These were two former Hidden Mist shinobi, known as the Demon Brothers, who had defected
+                            <p class="filp-card__text">These were two former Hidden Mist shinobi, known as the Demon Brothers, who had defected
                                 from their village in order to join Zabuza's coup.
 
                                 Kakashi and Sasuke were able to easily dispose of the Demon Brothers and keep Tazuna
@@ -727,17 +726,17 @@
 
                 <!-- Madara card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Madara Uchiha</h2>
-                            <img class="img_card" src="Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">Madara Uchiha was the legendary leader of the Uchiha clan. He founded
+                            <p class="filp-card__text filp-card__text--main">Madara Uchiha was the legendary leader of the Uchiha clan. He founded
                                 Konohagakure alongside his childhood friend and rival, Hashirama Senju, with the
                                 intention of beginning an era of peace.</p>
-                            <p class="card-text"> When the two couldn't agree on how to achieve that peace, they fought for control of the
+                            <p class="filp-card__text"> When the two couldn't agree on how to achieve that peace, they fought for control of the
                                 village, a conflict which ended in Madara's death. Madara, however, rewrote his death
                                 and went into hiding to work on his own plans. Unable to complete it in his natural
                                 life, he entrusted his knowledge and plans to Obito shortly before his actual death.
@@ -750,15 +749,15 @@
                 <!--Madara card end-->
                 <!-- Tayuya Card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Tayuya</h2>
-                            <img class="img_card" src="./Images/tayuya.jpg" alt="Tayuya Image" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/tayuya.jpg" alt="Tayuya Image" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">A kunoichi from The Hidden Sound Village and a member of The Sound
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">A kunoichi from The Hidden Sound Village and a member of The Sound
                                 Five.</p>
-                            <p class="card-text">Tayuya is one of Orochimaru's Sound Four Ninja. She is foul mouthed and ill tempered yet
+                            <p class="filp-card__text">Tayuya is one of Orochimaru's Sound Four Ninja. She is foul mouthed and ill tempered yet
                                 very powerful. Her only weapon is a flute which she can use to summon three giant demons
                                 known as the Doki. Tayuya is also very intelligent and can think up excellent strategies
                                 and tactics.</p>
@@ -768,15 +767,15 @@
                 <!-- Tayuya Card End -->
                 <!-- [character name] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kagura</h2>
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/16/164924/2399930-kagura.png"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/scale_small/16/164924/2399930-kagura.png"
                                 alt="Kagura" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">The main villain of Clash of Ninja Revolution 2, she's an ex-ANBU
+                            <p class="filp-card__text filp-card__text--main">The main villain of Clash of Ninja Revolution 2, she's an ex-ANBU
                                 member.</p>
 
                         </div>
@@ -786,14 +785,14 @@
 
                 <!-- [character name] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Tenten</h2>
-                            <img class="img_card" src="Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">Tenten is one of the main supporting characters in the Naruto
+                            <p class="filp-card__text filp-card__text--main">Tenten is one of the main supporting characters in the Naruto
                                 anime/manga series and the Boruto: Naruto Next Generations anime/manga series. Shis a
                                 chūnin-level kunoichi of Konohagakure and member of Team Guy</p>
 
@@ -803,15 +802,15 @@
                 <!--[character name] card end-->
                 <!-- Itachi Uchiha card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Itachi Uchiha</h2>
-                            <img class="img_card" src="images/Itachi.png" alt="Itachi Uchiha" height="300px" width="300px">
+                            <img class="flip-card__image" src="images/Itachi.png" alt="Itachi Uchiha" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Itachi Uchiha is a fictional character in the Naruto manga and anime
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Itachi Uchiha is a fictional character in the Naruto manga and anime
                                 series created by Masashi Kishimoto.</p>
-                            <p class="card-text">Itachi is the older brother of Sasuke Uchiha, and is responsible for killing all the
+                            <p class="filp-card__text">Itachi is the older brother of Sasuke Uchiha, and is responsible for killing all the
                                 members of their clan, sparing only Sasuke. He appears working as a terrorist from the
                                 organisation Akatsuki and serves as Sasuke's greatest enemy. During the second part of
                                 the manga, Itachi becomes involved in attacks to ninjas possessing tailed-beast
@@ -824,13 +823,13 @@
                 <!--Itachi Uchiha card end-->
                 <!-- Isaribi card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Isaribi</h2>
-                            <img class="img_card" src="Images/Isaribi.jpg" alt="Isaribi" height="280px" width="400px">
+                            <img class="flip-card__image" src="Images/Isaribi.jpg" alt="Isaribi" height="280px" width="400px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main"> Isaribi was a part sea creature whose charecter arc was similar to
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main"> Isaribi was a part sea creature whose charecter arc was similar to
                                 that of Naruto. She received a lot of hate for not being/behaving like the other members
                                 of her clan. Naruto shows her the power of friendship and fills her with hope. Amachi-
                                 the scientist to made Isaribi into the sea creature clearly exrpesses he had no
@@ -844,15 +843,15 @@
 
                 <!-- Kurama card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kurama</h2>
 
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/original/13/135472/2264772-narutoninjastorm3battle016.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/original/13/135472/2264772-narutoninjastorm3battle016.jpg"
                                 alt="Kurama" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Kurama is the Nine-Tailed Fox demon that resides within Naruto and
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Kurama is the Nine-Tailed Fox demon that resides within Naruto and
                                 augments his power. He is the most powerful tailed beast. His power is equivalent to
                                 all the eight tailed beasts. He was in contract with Madara Uchicha during the era of
                                 first
@@ -872,15 +871,15 @@
 
                 <!-- Hiashi Hyūga card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hiashi Hyūga</h2>
-                            <img class="img_card" src="images/Hiashi_Hyuga.png" alt="Hiashi Hyuga" height="300px" width="300px">
+                            <img class="flip-card__image" src="images/Hiashi_Hyuga.png" alt="Hiashi Hyuga" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hiashi Hyuga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hiashi Hyuga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
                                 well as the current head of the Hyūga clan.</p>
-                            <p class="card-text">Hiashi was born only seconds before his twin brother Hizashi, making Hiashi the head of
+                            <p class="filp-card__text">Hiashi was born only seconds before his twin brother Hizashi, making Hiashi the head of
                                 the Hyūga clan and Hizashi a member of the branch house, whose only purpose in life
                                 would be to protect members of the main house. Years later, when Neji was born, Hizashi
                                 became bitter that his son would never be able to reach his full potential like a member
@@ -894,16 +893,16 @@
 
                 <!-- Bansai Card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Bansai</h2>
 
-                            <img class="img_card" src="./Images/bansai.png" alt="Bansai" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/bansai.png" alt="Bansai" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Bansai is an elder ninja monk in the Fire Temple as well as the Head
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Bansai is an elder ninja monk in the Fire Temple as well as the Head
                                 Monk of the temple.</p>
-                            <p class="card-text">Bansai is a very kind person who cares about his comrades deeply as seen when he said a
+                            <p class="filp-card__text">Bansai is a very kind person who cares about his comrades deeply as seen when he said a
                                 prayer for Asuma Sarutobi before he set out for battle.</p>
                         </div>
                     </div>
@@ -912,14 +911,14 @@
                 <!-- Minato card start -->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Minato Namikaze</h2>
 
-                            <img class="img_card" src="Images/minatoNew.jpg" alt="Minato" height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/minatoNew.jpg" alt="Minato" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Minato Namikaze is a character in the Naruto universe. He is better
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Minato Namikaze is a character in the Naruto universe. He is better
                                 known as The Fourth Hokage or as Konoha's Yellow Flash for his ability to use the Flying
                                 Thunder God Technique. He is also the father of series protagonist, Naruto. He is the
                                 teacher of Kakashi Hatake, Obito Uchiha and Rin Nohara. He is also one of Jiraiya's
@@ -931,20 +930,20 @@
 
                 <!-- rajulkoshta Card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kawaki</h2>
 
-                            <img class="img_card" src="./Images/kawaki2.jpg" alt="kawaki" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/kawaki2.jpg" alt="kawaki" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Kawaki (カワキ, Kawaki) is a tattooed youth who became a member of Kara
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Kawaki (カワキ, Kawaki) is a tattooed youth who became a member of Kara
                                 after being brought by Jigen from a drunkard father, bearing a tattoo of the Roman
                                 numeral IX under his left eye and bestowed a Kama mark by Jigen to be made into a living
                                 weapon for Kara. He was heavily modified with microscopic Shinobi-Ware implanted in his
                                 body that give him abilities similar to Jugo's Sage Transformation in altering his
                                 physiology at a cellular level.</p>
-                            <p class="card-text"> For reasons yet to be revealed, Kawaki left Kara and encountered Boruto who brings him
+                            <p class="filp-card__text"> For reasons yet to be revealed, Kawaki left Kara and encountered Boruto who brings him
                                 to the Hidden Leaf as he lives with the Uzumaki family. The two would end up becoming
                                 enemies as hinted in prologue of the Boruto series, an older Kawaki appearing to have
                                 perpetrated Konoha's destruction as he confronts an older Boruto while declaring the age
@@ -956,14 +955,14 @@
 
                 <!-- Eida Card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Eida</h2>
 
-                            <img class="img_card" src="./Images/eida.png" alt="Eida" height="350px" width="350px">
+                            <img class="flip-card__image" src="./Images/eida.png" alt="Eida" height="350px" width="350px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">In his plot to kill Jigen, Amado heavily modified Eida, along with her
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">In his plot to kill Jigen, Amado heavily modified Eida, along with her
                                 younger brother Daemon with Shinobi-Ware with capabilities exceeding that of Jigen.
                                 The effects of her modifications left her forever despising Amado.
                                 Because of her superior might, Jigen had ordered for her disposal.
@@ -971,7 +970,7 @@
                                 However, affected by Eida's powers, Boro could not bring himself to complete the task,
                                 and instead hid Eida and Daemon in a remote location operated by his cult for his own
                                 uses.</p>
-                            <p class="card-text"> Eida is a very cold and indifferent person.
+                            <p class="filp-card__text"> Eida is a very cold and indifferent person.
                                 She cares little for the events around her.
                                 This comes from having grown bored in the life that was forced upon her.
                             </p>
@@ -982,14 +981,14 @@
 
                 <!-- Daemon Card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Daemon</h2>
 
-                            <img class="img_card" src="./Images/Daemon.webp" alt="Daemon" height="350px" width="350px">
+                            <img class="flip-card__image" src="./Images/Daemon.webp" alt="Daemon" height="350px" width="350px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Daemon used to be a member of Kara.
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Daemon used to be a member of Kara.
                                 He was one of the cyborgs that Isshiki ordered to be dismantled.
                                 However, Boro was allured by Ada, and he couldn't bring himself to finish the task, and
                                 he was manipulated to safely store Ada and Daemon in pods for several years.
@@ -1001,14 +1000,14 @@
 
                 <!-- card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Nagato Uzumaki</h2>
 
-                            <img class="img_card" src="./Images/nagato.png" alt="Nagato Uzumaki" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/nagato.png" alt="Nagato Uzumaki" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Nagato was known primarily under the alias of Pain. Nagato is the
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Nagato was known primarily under the alias of Pain. Nagato is the
                                 figurehead leader of the Akatsuki who wishes to capture the tailed beasts sealed into
                                 various people around the shinobi world. After acquiring and sealing most
                                 of the beasts within a statue, Nagato's superior sends him to capture the Nine-Tailed
@@ -1024,14 +1023,14 @@
 
                 <!--card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">YAMATO</h2>
 
-                            <img class="img_card" src="./Images/yamato.png" alt="Nagato Uzumaki" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/yamato.png" alt="Nagato Uzumaki" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Seeing how pivotal of a role Kakashi played as the leader of Team Seven
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Seeing how pivotal of a role Kakashi played as the leader of Team Seven
                                 with Naruto, Sakura, and Sasuke, there were high expectations for Yamato when he
                                 temporarily filled Kakashi's leadership position with the new Team Seven.
 
@@ -1049,15 +1048,15 @@
 
                 <!-- Hashirama Senju card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hashirama Senju </h2>
 
-                            <img class="img_card" src=https://www.giantbomb.com/a/uploads/scale_small/3/33873/1727699-first_hokage.jpg
+                            <img class="flip-card__image" src=https://www.giantbomb.com/a/uploads/scale_small/3/33873/1727699-first_hokage.jpg
                                 alt="Hashirama Senju image" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The First hokage, leader of the Senju clan, one of the founders of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The First hokage, leader of the Senju clan, one of the founders of
                                 Konohagakure. Older brother to the Second Hokage and Grandfather to the Fifth Hokage. He
                                 possesses the Wood Style and has a friend and rival called Madara Uchiha. He was the
                                 incarnation of Asura.
@@ -1074,19 +1073,19 @@
 
                 <!-- card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Yahiko </h2>
 
-                            <img class="img_card" src="./Images/Yahiko.png" alt="anko" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/Yahiko.png" alt="anko" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Yahiko (弥彦, Yahiko) was a shinobi from Amegakure. Alongside his fellow
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Yahiko (弥彦, Yahiko) was a shinobi from Amegakure. Alongside his fellow
                                 war orphans, Nagato and Konan, he founded and led the Akatsuki in an attempt to bring
                                 peace. Following Yahiko's death, Nagato would turn his body into the
                                 Deva Path of his Six Paths of Pain, which he used as the continued public image of
                                 Akatsuki's leadership.</p>
-                            <p class="card-text"> Yahiko was orphaned during the Second Shinobi World War, forcing him to steal food in
+                            <p class="filp-card__text"> Yahiko was orphaned during the Second Shinobi World War, forcing him to steal food in
                                 order to survive prior to teaming
                                 up with a fellow war orphan named Konan. Soon after they found a place to call home,
                                 Yahiko expressed his displeasure from Konan bringing another war orphan. </p>
@@ -1094,16 +1093,16 @@
                     </div>
                 </div>
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Deidara</h2>
 
-                            <img class="img_card" src="./Images/deidara69.jpg" alt="Deidara" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/deidara69.jpg" alt="Deidara" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Deidara is a member of the Akatsuki group, Deidara was partnered with
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Deidara is a member of the Akatsuki group, Deidara was partnered with
                                 Sasori before his death, after which he partnered Tobi.</p>
-                            <p class="card-text">Deidara has a very unique ability, he uses his hands where his palms posses mouths that
+                            <p class="filp-card__text">Deidara has a very unique ability, he uses his hands where his palms posses mouths that
                                 when feed a certain clay explosive can create a flying bird or many small spiders that
                                 can be controlled or control them self after which will explode on command or when they
                                 deem suitable.</p>
@@ -1115,14 +1114,14 @@
                 <!--card end-->
                 <!-- card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Tsuande </h2>
 
-                            <img class="img_card" src="./Images/Tsunadexx.png" alt="anko" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/Tsunadexx.png" alt="anko" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Tsunade (綱手, Tsunade) is a descendant of the Senju and Uzumaki Clan,
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Tsunade (綱手, Tsunade) is a descendant of the Senju and Uzumaki Clan,
                                 and is one of Konohagakure's Sannin. She is famed as the world's strongest kunoichi and
                                 its greatest medical-nin. The repeated loss of her loved ones caused Tsunade to later
                                 abandon the life of a shinobi for many years. She is eventually persuaded to return to
@@ -1135,14 +1134,14 @@
                 <!--card end-->
                 <!--card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">KIMIMARO</h2>
 
-                            <img class="img_card" src="./Images/kimimaro.png" alt="kimimaro" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/kimimaro.png" alt="kimimaro" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">
                                 Kimimaro was the sole survivor of the Kaguya clan. Upon dedicating his life to
                                 Orochimaru, he became the leader of the formerly-named Sound Five (音隠れの忍五人衆, Otogakure
                                 no Shinobi Gonin Shū, literally meaning: Hidden Sound Shinobi Five People), until he
@@ -1154,15 +1153,15 @@
                 <!-- card start -->
                 <!-- [character name] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Zabuza</h2>
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/3/34651/3376238-zabuza.png"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/scale_small/3/34651/3376238-zabuza.png"
                                 alt="Zabuza" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">Zabuza Momochi, a mercenary assassin and former member of the Seven
+                            <p class="filp-card__text filp-card__text--main">Zabuza Momochi, a mercenary assassin and former member of the Seven
                                 Swordsmen of the Mist. He is a master of silent assassinations
                                 and together with his water Jutsu he is feared as The Demon of the Hidden Mist. He was
                                 defeated by Kakashi and he gave his live to compensate the feelingof sorrow he felt
@@ -1175,17 +1174,17 @@
                 <!--[character name] card end-->
                 <!-- Haku card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Haku </h2>
 
-                            <img class="img_card" src="./Images/Casual_Haku.png" alt="Haku" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/Casual_Haku.png" alt="Haku" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Haku was an orphan from the Land of Water, and a descendant of the Yuki
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Haku was an orphan from the Land of Water, and a descendant of the Yuki
                                 clan. He later became a shinobi under Zabuza Momochi's tutelage whom he later partnered
                                 with, ultimately becoming a Mercenary Ninja</p>
-                            <p class="card-text">Haku was a 15-year-old boy with an androgynous appearance and was even viewed as being
+                            <p class="filp-card__text">Haku was a 15-year-old boy with an androgynous appearance and was even viewed as being
                                 beautiful by Naruto, who exclaimed that he was "prettier than Sakura", even after he
                                 informed him that he was male. He had long black hair, pale skin and large, dark-brown
                                 eyes, and a slender frame.</p>
@@ -1197,15 +1196,15 @@
 
                 <!-- Tonton card start -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Tonton </h2>
 
-                            <img class="img_card" src="./Images/Tonton.png" alt="Tonton" height="350px" width="380px">
+                            <img class="flip-card__image" src="./Images/Tonton.png" alt="Tonton" height="350px" width="380px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Tonton is Tsunade's ninja pig, often kept in the care of Shizune.</p>
-                            <p class="card-text">Above all else, Tonton is a highly devoted, and dutiful pet pig. Her devotion to Tsunade
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Tonton is Tsunade's ninja pig, often kept in the care of Shizune.</p>
+                            <p class="filp-card__text">Above all else, Tonton is a highly devoted, and dutiful pet pig. Her devotion to Tsunade
                                 was noted during her master's battle with the other Sannin, which she watched in earnest
                                 as Gamakichi and Gamatatsu bickered. This even surfaced during the Fourth Shinobi World
                                 War, where, in her earnest to aid the Logistical Support and Medical Division, Tonton
@@ -1220,19 +1219,19 @@
                 <!-- first card end-->
                 <!-- card start  -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Sand Siblings</h2>
 
-                            <img class="img_card" src="./Images/sand siblings.jpeg" alt="Sand-Siblings" height="350px" width="250px">
+                            <img class="flip-card__image" src="./Images/sand siblings.jpeg" alt="Sand-Siblings" height="350px" width="250px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">
                                 The Three Sand Siblings is the collective name for the children of Sunagakure's Fourth
                                 Kazekage: Temari, Kankurō and Gaara. Having undergone the gruelling training of their
                                 village, these three are regarded as elite shinobi of their village that excel
                                 in long-range combat. </p>
-                            <p class="card-text">Some time after the Konoha Crush failed, its members were promoted: Gaara became the
+                            <p class="filp-card__text">Some time after the Konoha Crush failed, its members were promoted: Gaara became the
                                 Kazekage, Kankurō and Temari became jōnin, Temari also becoming an ambassador.In Part
                                 II, Temari and Kankurō attended Gaara to the Five Kage
                                 Summit as his bodyguards.
@@ -1246,17 +1245,17 @@
 
                 <!-- Hidan card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hidan</h2>
 
-                            <img class="img_card" src="./Images/Hidan.png" alt="Hidan" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Hidan.png" alt="Hidan" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hidan is an S-rank missing-nin who defected from Yugakure and later
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hidan is an S-rank missing-nin who defected from Yugakure and later
                                 joined the Akatsuki. There, he was partnered with Kakuzu,
                                 despite the two's somewhat mutual dislike of each other.</p>
-                            <p class="card-text">Hidan doesn't always seem like the most intelligent of the Akatsuki. He certainly doesn't
+                            <p class="filp-card__text">Hidan doesn't always seem like the most intelligent of the Akatsuki. He certainly doesn't
                                 have the knack for long-term planning that Pain or Tobi do,
                                 for example. Hidan does, however, much like Kakuzu, have a great understanding of
                                 anatomy and just how shinobi abilities work. That's how he
@@ -1269,20 +1268,20 @@
 
                 <!-- card start  -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Sakon & Ukon</h2>
 
-                            <img class="img_card" src="./Images/sakon_ukon.jpg" alt="sakon and ukon" height="350px" width="250px">
+                            <img class="flip-card__image" src="./Images/sakon_ukon.jpg" alt="sakon and ukon" height="350px" width="250px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">
                                 They work for Orochi-Maru, an evil genius dead set on discovering and mastering every
                                 jutsu in the world. Sakon and Ukon are one his main pawns, as a member of the sound 5
                                 (Dark sound ninja with horrifying skills and abilities.)
                             </p>
 
-                            <p class="card-text">
+                            <p class="filp-card__text">
                                 Sakon and Ukon have the ability to when touching there opponent attach there cells to
                                 their opponents, there for, making them one and slowly killing there opponents cells in
                                 place for there own. No one had ever survived it but no one had ever been as
@@ -1297,18 +1296,18 @@
                 <!--Konan card end-->
                 <!-- Zabuza card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Zabuza</h2>
 
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/square_small/0/534/178998-zabuza.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/square_small/0/534/178998-zabuza.jpg"
                                 alt=Zabuza height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Zabuza Momochi (桃地再不斬, Momochi Zabuza), given the moniker Demon of the
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Zabuza Momochi (桃地再不斬, Momochi Zabuza), given the moniker Demon of the
                                 Hidden Mist (霧隠れの鬼人, Kirigakure no Kijin), was a missing-nin from Kirigakure's Seven
                                 Ninja Swordsmen of the Mist.</p>
-                            <p class="card-text">As a Hidden Mist ninja, Zabuza's forte is using water-nature chakra to manipulate water
+                            <p class="filp-card__text">As a Hidden Mist ninja, Zabuza's forte is using water-nature chakra to manipulate water
                                 to take in many forms as he wishes such as creating Water Clones. Among his abilities is
                                 the Water Dragon jutsu where he creates a serpentine dragon out of water to consume his
                                 target.</p>
@@ -1319,19 +1318,19 @@
 
                 <!--Tenten card end-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Tenten</h2>
 
-                            <img class="img_card" src="./Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">In the Konoha 11, which consists of many of Naruto's peers in Team
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">In the Konoha 11, which consists of many of Naruto's peers in Team
                                 Seven, Team Eight, Team Ten, and Team Guy, there are ninjas like Rock Lee who excel in
                                 taijutsu as well as ninjas who are considered geniuses like Shikamaru
                                 and Neji. There is one ninja among the eleven, however, who definitely falls short of
                                 the spotlight--Tenten</p>
-                            <p class="card-text">While Tenten was introduced as a character who specializes in ninja tools and weapons,
+                            <p class="filp-card__text">While Tenten was introduced as a character who specializes in ninja tools and weapons,
                                 there is little that we know about her clan and background. Even in her most well-known
                                 battle against Temari during the Chunin Exams, she
                                 was practically defeated before anyone had a chance to see her true fighting
@@ -1343,16 +1342,16 @@
 
                 <!-- Might Guy card-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Might Guy</h2>
 
-                            <img class="img_card" src="./Images/GuyGawd.png" alt="Might Guy" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/GuyGawd.png" alt="Might Guy" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Might Guy (マイト・ガイ, Maito Gai) is a jōnin of Konohagakure. A master of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Might Guy (マイト・ガイ, Maito Gai) is a jōnin of Konohagakure. A master of
                                 taijutsu, Guy leads and passes his wisdom onto the members of Team Guy.</p>
-                            <p class="card-text">Guy is the son of Might Duy, who was known throughout Konoha as the "Eternal Genin". Duy
+                            <p class="filp-card__text">Guy is the son of Might Duy, who was known throughout Konoha as the "Eternal Genin". Duy
                                 was not bothered by this moniker and instead was grateful that other people cared enough
                                 to know him at all. Duy encouraged this same kind of optimism in Guy, as well as his
                                 belief that one always has youth and that they could both become taijutsu masters
@@ -1364,22 +1363,22 @@
                 <!--Might Guy card end-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Asuma Sarutobi</h2>
 
-                            <img class="img_card" src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
+                            <img class="flip-card__image" src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
                                 who always enjoys a good smoke. He goes out with Kurenai, a strong Genjutsu user.
                                 Revealed to be the son of Hiruzen Sarutobi, the third Hokage and is uncle
                                 to Konohamaru Sarutobi. Jonin squad leader of Team 10, the current Ino-Shika-Chou Trio
                                 until he meets his end by the Akatsuki Member, Hidan. He was later resurrected with the
                                 impure world resurrection technique to participate
                                 in the Fourth Shinobi World War.</p>
-                            <p class="card-text">His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
+                            <p class="filp-card__text">His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
                                 team which served to protect the Land of Fire's daimyō — a role which later earned him a
                                 bounty of 35,000,000 ryō.[9][21] He could effortlessly
                                 take down nine Oto-nin during the Konoha Crush, noted to have been chūnin-level or
@@ -1391,19 +1390,19 @@
                 </div>
                 <!-- card end-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hidan</h2>
 
-                            <img class="img_card" src="./Images/Hidan.jpg" alt="Hidan" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Hidan.jpg" alt="Hidan" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hidan (飛段) is the immortal, foul-mouthed, and sadomasochistic partner
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hidan (飛段) is the immortal, foul-mouthed, and sadomasochistic partner
                                 of Kakuzu and a former ninja of Yugakure, the Village Hidden in Boiling Water. He is a
                                 member of the Way of Jashin (ジャシン, lit. "evil god") religion which
                                 worships a deity of the same name and believes that anything less than death and utter
                                 destruction in battle is a sin.</p>
-                            <p class="card-text">Hidan can create a link with his opponent. Once this link is created, any damage done to
+                            <p class="filp-card__text">Hidan can create a link with his opponent. Once this link is created, any damage done to
                                 Hidan's body is reflected on his opponent, allowing him to kill them by giving himself
                                 fatal injuries. Though his immortality keeps him
                                 from dying or suffer any impairment, Hidan feels his victims' suffering with an
@@ -1418,18 +1417,18 @@
 
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kakashi Hatake</h2>
 
-                            <img class="img_card" src="./Images/kakashi.jpg" alt="Naruto Uzumaki" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/kakashi.jpg" alt="Naruto Uzumaki" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
                                 village. He is the teacher (sensei) of Uzumaki Naruto, Haruno Sakura and Uchiha Sasuke.
                                 His teacher was the fourth hokage, Minato Namikaze and his teammates
                                 were Obito Uchiha and Rin Nohara. His rival is Might Guy.</p>
-                            <p class="card-text">He's worked and thrived at all levels, including among the ANBU. He has a summoning
+                            <p class="filp-card__text">He's worked and thrived at all levels, including among the ANBU. He has a summoning
                                 ability with a pack of Ninja Dogs, one of which speaks and all of which are excellent
                                 trackers. He's never been shown without his masks on.
                                 He wears at least two of them, and even his close friends don't know what he looks like.
@@ -1441,18 +1440,18 @@
 
                 <!-- Fugaku card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Fugaku</h2>
 
-                            <img class="img_card" src="./Images/fugaku.jpeg" alt="Fugaku" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/fugaku.jpeg" alt="Fugaku" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Fugaku Uchiha (うちはフガク, Uchiha Fugaku) was a shinobi of Konohagakure. He
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Fugaku Uchiha (うちはフガク, Uchiha Fugaku) was a shinobi of Konohagakure. He
                                 was the head of the Uchiha clan as well as the leader of the Konoha Military Police
                                 Force.
                             </p>
-                            <p class="card-text">Fugaku Uchiha was as strong as fourth hokage Minato Namikaze. Let's talk about the great
+                            <p class="filp-card__text">Fugaku Uchiha was as strong as fourth hokage Minato Namikaze. Let's talk about the great
                                 ninja war. Minato killed an 1000 strong army using the “flying thunder god" ie hirashino
                                 jutsu. In that same war Fugaku killed countless
                                 using genjutsu alone. One of his comrades died covering him and he unlocked the Mangekyo
@@ -1466,15 +1465,15 @@
 
                 <!-- Inari card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Inari</h2>
 
-                            <img class="img_card" src="./Images/inari.png" alt="Fugaku" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/inari.png" alt="Fugaku" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
-                            <p class="card-text">Inari is the son of Tsunami, and is also Tazuna's grandson. His biological father died
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
+                            <p class="filp-card__text">Inari is the son of Tsunami, and is also Tazuna's grandson. His biological father died
                                 before he got to know him.
                             </p>Inari first appeared to be a very tough individual, though this was just a ruse he put
                             on to hide the loneliness he felt since the death of Kaiza. He would often spend most of his
@@ -1487,23 +1486,23 @@
 
                 <!-- Third Raikage card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Third Raikage</h2>
 
-                            <img class="img_card" src="Images/Raikage3.png" alt="Fugaku" height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/Raikage3.png" alt="Fugaku" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
                                 Lightning Shadow) of Kumogakure, was renowned to be the greatest Raikage the village has
                                 ever had.</p>
-                            <p class="card-text">The Third Raikage's rule was punctuated by the berserk attacks of the Eight-Tails but as
+                            <p class="filp-card__text">The Third Raikage's rule was punctuated by the berserk attacks of the Eight-Tails but as
                                 Kumogakure couldn't afford to dispose of such a valuable war deterrent, he was forced to
                                 look for a suitable jinchūriki in quick succession, after the conclusion of each
                                 rampage. During one of these attacks, he fought the Eight-Tails alone, allowing his
                                 comrades to escape. Their battle resulted in him receiving a self-inflicted wound to the
                                 chest after he collapsed upon his own hand, which became his life's shame.</p>
-                            <p class="card-text">Since this event, he made it a personal duty to combat the Eight-Tails whenever its
+                            <p class="filp-card__text">Since this event, he made it a personal duty to combat the Eight-Tails whenever its
                                 jinchūriki lost control, eventually making even his son become part of the group that
                                 supported him during these occurrences. He chose to seal the Eight-Tails in the Kohaku
                                 no Jōhei, resulting in his nephew's death, hoping that someone else would have more
@@ -1515,18 +1514,18 @@
 
                 <!-- Mikoto card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Mikoto Uchiha</h2>
 
-                            <img class="img_card" src="https://wallpapercave.com/wp/wp4126361.png" alt="Mikoto" height="300px"
+                            <img class="flip-card__image" src="https://wallpapercave.com/wp/wp4126361.png" alt="Mikoto" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Mikoto Uchiha (うちはミコト, Uchiha Mikoto) was a jōnin from Konohagakure's
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Mikoto Uchiha (うちはミコト, Uchiha Mikoto) was a jōnin from Konohagakure's
                                 Uchiha clan.
                             </p>
-                            <p class="card-text">Mikoto was a very gentle and kind woman, but could also be stern and strict when she
+                            <p class="filp-card__text">Mikoto was a very gentle and kind woman, but could also be stern and strict when she
                                 needed to be, as seen when Itachi came back from the Academy and she told Sasuke that he
                                 could not play because he had homework. She loved
                                 her sons deeply and knew how to help them with their problems. Mikoto cared for and also
@@ -1541,21 +1540,21 @@
 
                 <!-- BlackZetsu card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Black Zetsu</h2>
 
-                            <img class="img_card" src="https://wallpapercave.com/wp/wp8345725.jpg" alt="BlackZetsu" height="300px"
+                            <img class="flip-card__image" src="https://wallpapercave.com/wp/wp8345725.jpg" alt="BlackZetsu" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Black Zetsu (黒ゼツ, Kuro Zetsu) was the physical manifestation of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Black Zetsu (黒ゼツ, Kuro Zetsu) was the physical manifestation of
                                 Princess Kaguya Ōtsutsuki's will. It secretly instigated many of the events that shaped
                                 the shinobi world to secure Kaguya's revival. To further its plans, it
                                 posed as Madara Uchiha's manifested will and then partnered with White Zetsu to become
                                 half of the Akatsuki member known simply as Zetsu (ゼツ, Zetsu).
                             </p>
-                            <p class="card-text">Black Zetsu was created by Kaguya Ōtsutsuki shortly before she was sealed as the
+                            <p class="filp-card__text">Black Zetsu was created by Kaguya Ōtsutsuki shortly before she was sealed as the
                                 Ten-Tails by her twin sons, Hagoromo and Hamura. In the anime, Black Zetsu would
                                 approach Indra alone periodically, goading him with praises and
                                 curiosity towards Indra's true potential, even going so far as to say he could rival if
@@ -1574,19 +1573,19 @@
 
                 <!-- Mito card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Mito Uzumaki</h2>
 
-                            <img class="img_card" src="./Images/MitoUzumaki.jpg" alt="Mito" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/MitoUzumaki.jpg" alt="Mito" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Mito Uzumaki (うずまきミト, Uzumaki Mito) was a kunoichi who originated from
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Mito Uzumaki (うずまきミト, Uzumaki Mito) was a kunoichi who originated from
                                 Uzushiogakure's Uzumaki clan. After migrating to Konohagakure, she married Hashirama
                                 Senju, the village's First Hokage, and later became the first jinchūriki
                                 of the Nine-Tails following the events at the Valley of the End.
                             </p>
-                            <p class="card-text">The Uzumaki and Senju clans — being distant relatives — have always had close ties. Mito
+                            <p class="filp-card__text">The Uzumaki and Senju clans — being distant relatives — have always had close ties. Mito
                                 ended up marrying Hashirama Senju, who would help found Konohagakure and became the
                                 village's First Hokage. After Hashirama's victory
                                 against Madara Uchiha at the Valley of the End and obtaining Kurama from him, Mito
@@ -1601,18 +1600,18 @@
 
                 <!-- Guren card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title"> Guren</h2>
 
-                            <img class="img_card" src="./Images/Guren.png" alt="Guren" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Guren.png" alt="Guren" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Guren (紅蓮, Guren) is a kunoichi from Otogakure and the leader of a
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Guren (紅蓮, Guren) is a kunoichi from Otogakure and the leader of a
                                 group of Orochimaru's subordinates,
                                 possessing the unique Crystal Release kekkei genkai.
                             </p>
-                            <p class="card-text">she was offered the chance to become one of Orochimaru's future vessels. When Sasuke
+                            <p class="filp-card__text">she was offered the chance to become one of Orochimaru's future vessels. When Sasuke
                                 Uchiha defected from Konohagakure and Kimimaro was no longer a
                                 suitable vessel for Orochimaru, Guren became the next best choice in Orochimaru's eyes.
                                 Unfortunately, by the time she arrived, Orochimaru couldn't
@@ -1627,18 +1626,18 @@
 
                 <!-- HANZO card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hanzō</h2>
 
-                            <img class="img_card" src="./Images/Hanzo-the-Salamander.jpg" alt="HANZO" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Hanzo-the-Salamander.jpg" alt="HANZO" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hanzō (半蔵, Hanzō), feared as Hanzō of the Salamander (山椒魚の半蔵, Sanshōuo
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hanzō (半蔵, Hanzō), feared as Hanzō of the Salamander (山椒魚の半蔵, Sanshōuo
                                 no Hanzō),
                                 was a legendary shinobi, and the leader of Amegakure during his lifetime.
                             </p>
-                            <p class="card-text">At some point during Hanzō's childhood, he found a black salamander with deadly venom
+                            <p class="filp-card__text">At some point during Hanzō's childhood, he found a black salamander with deadly venom
                                 residing in his village.
                                 When it died, its venom sac was embedded into his body in the hopes of creating a
                                 venomous ninja who himself was immune to toxins.
@@ -1654,21 +1653,21 @@
 
                 <!-- Konan card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Konan</h2>
 
-                            <img class="img_card" src="https://cdnb.artstation.com/p/assets/images/images/029/881/599/medium/lilimonada-lilimon-konan.jpg?1598920736"
+                            <img class="flip-card__image" src="https://cdnb.artstation.com/p/assets/images/images/029/881/599/medium/lilimonada-lilimon-konan.jpg?1598920736"
                                 alt="Konan" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Konan (小南, Konan) was a kunoichi from Amegakure and a founding member
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Konan (小南, Konan) was a kunoichi from Amegakure and a founding member
                                 of the original Akatsuki. After Yahiko's death, she was partnered with Nagato, who had
                                 since taken control of Akatsuki, and was the only member to call him
                                 by his name. After Nagato's death, Konan defected from Akatsuki and became the de facto
                                 village head of Amegakure.
                             </p>
-                            <p class="card-text">When she was young, Konan's family was killed during the Second Shinobi World War, and
+                            <p class="filp-card__text">When she was young, Konan's family was killed during the Second Shinobi World War, and
                                 she was left to fend for herself.[4] Some time later, Yahiko found her, and the two
                                 worked together to survive. Not long after that, Konan
                                 went for a walk and found a young, dying Nagato and his dog, Chibi. She rescued him and
@@ -1685,17 +1684,17 @@
 
                 <!-- Kidomaru card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kidomaru</h2>
 
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330403-kidomaru.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330403-kidomaru.jpg"
                                 alt="Kidomaru" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
-                            <p class="card-text card-text--main">A ninja from The Hidden Sound Village and member of The Sound Five.</p>
-                            <p class="card-text">Kidomaru was killed fighting against Neji Hyuga</p>
+                            <p class="filp-card__text filp-card__text--main">A ninja from The Hidden Sound Village and member of The Sound Five.</p>
+                            <p class="filp-card__text">Kidomaru was killed fighting against Neji Hyuga</p>
                         </div>
                     </div>
                 </div>
@@ -1704,14 +1703,14 @@
 		    
 		<!-- Karin card start-->
 		    <div class="flip-card">
-			<div class="flip-card-inner">
-			    <div class="flip-card-front">
+			<div class="flip-card__inner">
+			    <div class="flip-card__front">
 				<h2 class="card-title">Karin</h2>
-				<img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt=Karin height="300px" width="300px">
+				<img class="flip-card__image" src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt=Karin height="300px" width="300px">
 			    </div>
-			    <div class="flip-card-back">
-				<p class="card-text card-text--main">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
-				<p class="card-text">Karin has been praised for her abilities by both Obito Uchiha and Orochimaru, the latter deciding to take her with him for that reason. Despite being mostly a non-combatant, Orochimaru referred to Karin as one of his good experiments,[4] and had enough faith in her skills to put her in charge of the Southern Hideout's prison, since she made escaping impossible. Karin later demonstrated these skills most predominantly during the Fourth Shinobi World War, where she destroyed much of Tobi's giant wooden statue.</p>
+			    <div class="flip-card__back">
+				<p class="filp-card__text filp-card__text--main">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
+				<p class="filp-card__text">Karin has been praised for her abilities by both Obito Uchiha and Orochimaru, the latter deciding to take her with him for that reason. Despite being mostly a non-combatant, Orochimaru referred to Karin as one of his good experiments,[4] and had enough faith in her skills to put her in charge of the Southern Hideout's prison, since she made escaping impossible. Karin later demonstrated these skills most predominantly during the Fourth Shinobi World War, where she destroyed much of Tobi's giant wooden statue.</p>
 			    </div>
 			</div>
 		    </div>
@@ -1721,17 +1720,17 @@
                 <!-- Ebisu card start-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Ebisu Sensei</h2>
 
-                            <img class="img_card" src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
                                 specialises in training elite ninja. He also served as the leader of Team Ebisu, which
                                 consisted of Konohamaru Sarutobi, Udon, and Moegi.</p>
-                            <p class="card-text">Ebisu is portrayed as a stern and "by-the-book" type of person. Initially, he expressed
+                            <p class="filp-card__text">Ebisu is portrayed as a stern and "by-the-book" type of person. Initially, he expressed
                                 hatred for Naruto Uzumaki, and believed he was nothing but a worthless nuisance and
                                 mocked his dream of becoming Hokage as he believes
                                 that only people of high lineage could amount to anything. Upon seeing what Naruto had
@@ -1749,21 +1748,21 @@
                 <!-- Tobirama card start-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Tobirama Senju</h2>
 
-                            <img class="img_card" src="./Images/tobirama senju.png" alt="Ebisu" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/tobirama senju.png" alt="Ebisu" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Tobirama Senju (千手扉間, Senju Tobirama) was a member of the renowned
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Tobirama Senju (千手扉間, Senju Tobirama) was a member of the renowned
                                 Senju clan, who together with his elder brother and the Uchiha clan, founded the first
                                 shinobi village: Konohagakure. Throughout his lifetime, Tobirama would
                                 work tirelessly to achieve political stability and implement the institutions that made
                                 the village system work, thus ensuring Konoha's continuity and prosperity. After his
                                 brother's death, he would earn the title of Second
                                 Hokage (二代目火影, Nidaime Hokage, literally meaning: Second Fire Shadow).</p>
-                            <p class="card-text">Like Hashirama before him, Tobirama tried to foster good relations with the other
+                            <p class="filp-card__text">Like Hashirama before him, Tobirama tried to foster good relations with the other
                                 villages. He planned an alliance between Konoha and Kumogakure, but during a formal
                                 ceremony he and the Second Raikage were attacked by the Gold
                                 and Silver Brothers and left near death. During the First Shinobi World War, Team
@@ -1776,19 +1775,19 @@
                 </div>
                 <!-- card end-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hinata Hyuga</h2>
 
-                            <img class="img_card" src="./Images/hinata.jpeg" alt="Hinata" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/hinata.jpeg" alt="Hinata" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hinata, the eldest of Hiashi Hyuga's two children, is raised as the
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hinata, the eldest of Hiashi Hyuga's two children, is raised as the
                                 heiress to Hyuga clan's main household due to Hiashi being the elder between him and his
                                 twin brother, Hizashi, and thereby making Hiashi head of the clan
                                 while Hizashi is demoted to the Branch House whose only purpose is to serve the upper
                                 branch.</p>
-                            <p class="card-text">Hinata also meets Naruto Uzumaki during her youth, developing an interest in him after he
+                            <p class="filp-card__text">Hinata also meets Naruto Uzumaki during her youth, developing an interest in him after he
                                 defends her while she is being bullied because of her eyes.[25] That event and Naruto's
                                 refusal to give up against adversity inspire
                                 Hinata to become a stronger person. However, Hinata's admiration for Naruto gradually
@@ -1799,16 +1798,16 @@
                 <!--card end-->
                 <!-- Hiashi Hyuga card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hiashi Hyuga</h2>
 
-                            <img class="img_card" src="./Images/hiashi.jpeg" alt="Hiashi" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/hiashi.jpeg" alt="Hiashi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
                                 well as the current head of the Hyūga clan.</p>
-                            <p class="card-text">Hiashi was born just seconds before his twin brother Hizashi, which makes Hiashi the mind
+                            <p class="filp-card__text">Hiashi was born just seconds before his twin brother Hizashi, which makes Hiashi the mind
                                 of this Hyūga clan. Since the leader of the Hyūga clan, Hiashi is undoubtedly a strong
                                 shinobi. He's well-versed in all of his clan's secret procedures and fighting style.
 
@@ -1823,22 +1822,22 @@
                 <!-- Konan card start-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Asuma Sarutobi</h2>
 
-                            <img class="img_card" src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
+                            <img class="flip-card__image" src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
                                 who always enjoys a good smoke. He goes out with Kurenai, a strong Genjutsu user.
                                 Revealed to be the son of Hiruzen Sarutobi, the third Hokage and is uncle
                                 to Konohamaru Sarutobi. Jonin squad leader of Team 10, the current Ino-Shika-Chou Trio
                                 until he meets his end by the Akatsuki Member, Hidan. He was later resurrected with the
                                 impure world resurrection technique to participate
                                 in the Fourth Shinobi World War.</p>
-                            <p class="card-text">His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
+                            <p class="filp-card__text">His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
                                 team which served to protect the Land of Fire's daimyō — a role which later earned him a
                                 bounty of 35,000,000 ryō.[9][21] He could effortlessly
                                 take down nine Oto-nin during the Konoha Crush, noted to have been chūnin-level or
@@ -1853,14 +1852,14 @@
                 <!-- Choza card start-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Choza Akimichi</h2>
 
-                            <img class="img_card" src="./Images/choza_akimichi.png" alt="Choza Akimichi" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/choza_akimichi.png" alt="Choza Akimichi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Choza Akimichi (秋道チョウザ, Akimichi Chōza) is a jōnin of Konohagakure and
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Choza Akimichi (秋道チョウザ, Akimichi Chōza) is a jōnin of Konohagakure and
                                 former teammate of Shikaku Nara and Inoichi Yamanaka. Together they were the previous
                                 Ino–Shika–Chō trio. He is also the fifteenth head of the Akimichi clan (秋道15代目当主,
                                 Akimichi Jūgodaime Tōshu).</p>
@@ -1870,14 +1869,14 @@
                 <!-- Choza card end-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Madara Uchiha</h2>
 
-                            <img class="img_card" src="./Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the
                                 Uchiha clan. He founded Konohagakure alongside his childhood friend and rival, Hashirama
                                 Senju, with the intention of beginning an era of peace. When thetwo couldn't agree on
                                 how to achieve that peace, they fought for control of the village, a conflict which
@@ -1891,31 +1890,31 @@
                 </div>
                 <!--Izuna Uchiha-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Izuna Uchiha</h2>
 
-                            <img class="img_card" src="./Images/Izuna_Uchiha.png" alt="Madara Uchiha" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Izuna_Uchiha.png" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Izuna Uchiha (うちはイズナ, Uchiha Izuna) was a shinobi of the Uchiha clan.
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Izuna Uchiha (うちはイズナ, Uchiha Izuna) was a shinobi of the Uchiha clan.
                                 He, along with his brother Madara, were renowned as the clan's two strongest members in
                                 their lifetime. </p>
                         </div>
                     </div>
                 </div>
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Hashirama Senju</h2>
 
-                            <img class="img_card" src="./Images/hashirama.jpg" alt="Hashirama Senju" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/hashirama.jpg" alt="Hashirama Senju" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The First hokage, leader of the Senju clan, one of the founders of
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The First hokage, leader of the Senju clan, one of the founders of
                                 Konohagakure. Older brother to the Second Hokage and Grandfather to the Fifth Hokage. He
                                 possesses the Wood Style and has a friend and rival called Madara Uchiha.</p>
-                            <p class="card-text">He also showed great tactical skill and deceptive abilities, waiting until Madara became
+                            <p class="filp-card__text">He also showed great tactical skill and deceptive abilities, waiting until Madara became
                                 so exhausted that he couldn't maintain his Sharingan to create a wood clone for Madara
                                 to strike down so he could attack from behind without
                                 his opponent even realising it.</p>
@@ -1924,17 +1923,17 @@
                 </div>
                 <!-- card end-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kaguya Otsutsuki</h2>
 
-                            <img class="img_card" src="./Images/Kaguya_Ōtsutsuki.png" alt=" " height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Kaguya_Ōtsutsuki.png" alt=" " height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Kaguya was the originator of shinobi in the world in which Naruto takes
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Kaguya was the originator of shinobi in the world in which Naruto takes
                                 place. She was once benevolent and respected, but became corrupted. She is the final
                                 villain to oppose Naruto's team in the manga.</p>
-                            <p class="card-text">The final boss of Naruto turned out to be a woman! Who could've seen that coming?! One
+                            <p class="filp-card__text">The final boss of Naruto turned out to be a woman! Who could've seen that coming?! One
                                 would begin to wonder if Kishimoto had finally turned over a new leaf and realized that
                                 women too can be characters who can be a lot more
                                 beyond their gender. But alas, such hopes were dashed immediately when fans realized
@@ -1949,16 +1948,16 @@
 
                 <!--Killer Bee Card Start  -->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Killer Bee</h2>
-                            <img class="img_card" src="./Images/KillerBee.png" alt="Killer Bee" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/KillerBee.png" alt="Killer Bee" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Killer B is a major supporting character in the anime and manga Naruto
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Killer B is a major supporting character in the anime and manga Naruto
                                 Shippuden. He is the host of Gyuki, The Eight-tailed demon Ox. He was a shinobi who
                                 trained Naruto and is partners with him while fighting Obito Uchiha.</p>
-                            <p class="card-text">Killer B (キラービー, Kirā Bī, Viz: Killer Bee) is a shinobi from Kumogakure. He is the most
+                            <p class="filp-card__text">Killer B (キラービー, Kirā Bī, Viz: Killer Bee) is a shinobi from Kumogakure. He is the most
                                 recent jinchūriki of the Eight-Tails, Gyūki, though, unlike his predecessors, he was
                                 able to befriend it and hone its power for Kumo's benefit. Despite being responsible for
                                 the village's protection, B aspires to be the world's greatest rapper.</p>
@@ -1970,16 +1969,16 @@
                 <!-- Card Start For Gamabunta -->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Gamabunta</h2>
 
-                            <img class="img_card" src="./Images/Gamabunta.png" alt="Gamabunta" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Gamabunta.png" alt="Gamabunta" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Gamabunta is a grumpy, stubborn and highly apathetic toad. He was
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Gamabunta is a grumpy, stubborn and highly apathetic toad. He was
                                 summoned by lord fourth Hokage , sensei Jiraiya and by Naruto.</p>
-                            <p class="card-text">Gamabunta can spew oil from his mouth and use it to enhance fire. He is one of the
+                            <p class="filp-card__text">Gamabunta can spew oil from his mouth and use it to enhance fire. He is one of the
                                 biggest summon animal in the series. He was firest summoned by naruto when he was
                                 Falling from potential death.</p>
                         </div>
@@ -1988,19 +1987,19 @@
                 <!-- Card End For Gamabunta-->
                 <!-- [juubi-japesh] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Juubi</h2>
 
 
-                            <img class="img_card" src="https://i.pinimg.com/originals/88/c5/35/88c53577f0186691253c551c5f34170a.jpg"
+                            <img class="flip-card__image" src="https://i.pinimg.com/originals/88/c5/35/88c53577f0186691253c551c5f34170a.jpg"
 
                                 alt="Juubi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The ten-tailed beast was created by Kaguya Otsutsuki and later had its
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The ten-tailed beast was created by Kaguya Otsutsuki and later had its
                                 chakra split into the nine tailed beasts.</p>
-                            <p class="card-text">The Ten-Tailed Beast (十尾, Jūbi) is the original, primordial demon of the Naruto universe.
+                            <p class="filp-card__text">The Ten-Tailed Beast (十尾, Jūbi) is the original, primordial demon of the Naruto universe.
                                 All nine of the tailed beasts are but portions of chakra divided from the Ten-Tails.
                                 madara uchiha's ultimate goal, the moon's eye plan, is to capture and merge all nine of
                                 the tailed beasts back into the Ten-Tails, and become its host to cast the reflection of
@@ -2012,16 +2011,16 @@
                 <!--[character name] card end-->
                 <!-- Card start For Matatabi-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Matatabi</h2>
 
-                            <img class="img_card" src="./Images/matatabi.png" alt="Matatabi" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/matatabi.png" alt="Matatabi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Matatabi also known as Two-Tails, is one of the nine tailed
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Matatabi also known as Two-Tails, is one of the nine tailed
                                 beast.Yugito Nii is the jinchūriki of her</p>
-                            <p class="card-text">Matatabi has shown to be respectful and polite towards others,she is completely engulfed
+                            <p class="filp-card__text">Matatabi has shown to be respectful and polite towards others,she is completely engulfed
                                 in blue flames.Matatabi also has flexible muscles, which grant it great speed despite
                                 its large size
                             </p>
@@ -2033,22 +2032,22 @@
 
                 <div class="flip-card">
 
-                    <div class="flip-card-inner">
+                    <div class="flip-card__inner">
 
-                        <div class="flip-card-front">
+                        <div class="flip-card__front">
 
                             <h2 class="card-title">Obito Uchiha </h2>
 
-                            <img class="img_card" src="https://wallpaperaccess.com/full/5536097.jpg" alt=Obito height="300px"
+                            <img class="flip-card__image" src="https://wallpaperaccess.com/full/5536097.jpg" alt=Obito height="300px"
                                 width="300px">
 
                         </div>
 
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
                             <h2 class="card-title">Obito Uchiha</h2>
 
-                            <p class="card-text card-text--main">
+                            <p class="filp-card__text filp-card__text--main">
 
                                 A character from the anime series Naruto. He claimed to be Madara Uchiha the man who
                                 fought the First Hokage, Hashirama. He is the main antagonist of the Naruto Series. He
@@ -2072,21 +2071,21 @@
 
                 <div class="flip-card">
 
-                    <div class="flip-card-inner">
+                    <div class="flip-card__inner">
 
-                        <div class="flip-card-front">
+                        <div class="flip-card__front">
 
                             <h2 class="card-title">Rin Nohara </h2>
 
-                            <img class="img_card" src="Images/Rin_Nohara.jpg" alt=Rin height="300px" width="300px">
+                            <img class="flip-card__image" src="Images/Rin_Nohara.jpg" alt=Rin height="300px" width="300px">
 
                         </div>
 
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
 
                             <h2 class="card-title">Rin Nohara</h2>
 
-                            <p class="card-text card-text--main">
+                            <p class="filp-card__text filp-card__text--main">
 
                                 Rin Nohara was a chūnin of Konohagakure and a member of Team Minato alongside Kakashi
                                 Hatake and Obito Uchiha. Rin was forcibly made a vessel for the Three-Tails (Isobu) as a
@@ -2101,16 +2100,16 @@
 
                 <!-- jiraiya card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Jiraiya</h2>
 
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_super/9/95613/2225257-jiraiya.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/scale_super/9/95613/2225257-jiraiya.jpg"
                                 alt=Jiraiya height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <h2 class="card-title">Jiraiya</h2>
-                            <p class="card-text card-text--main">
+                            <p class="filp-card__text filp-card__text--main">
                                 Jiraiya is one of the "Three Legendary Sannin" that is known through out the ninja
                                 world. Jiraiya is the teacher of many characters in the Naruto universe including
                                 Naruto and the 4th Hokage. He is a renowned pervert and author of many adult books.
@@ -2129,18 +2128,18 @@
 
                 <!-- Iruka Umino card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Iruka Umino</h2>
 
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/square_small/1/17433/595228-iruka.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/square_small/1/17433/595228-iruka.jpg"
                                 alt="Iruka Umino" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Iruka Umino</h2>
 
-                                <p class="card-text card-text--main">The main teacher in the ninja acedemy he grow up like Naruto as
+                                <p class="filp-card__text filp-card__text--main">The main teacher in the ninja acedemy he grow up like Naruto as
                                     an orphan and thus acts like a father to Naruto. The man that voices Iruka umino
                                     is Quinton Flynn.</p>
                             </div>
@@ -2152,16 +2151,16 @@
 
                 <!-- Orochimaru card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Orochimaru</h2>
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/square_medium/0/5892/482861-naruto_orochi0244.jpg"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/square_medium/0/5892/482861-naruto_orochi0244.jpg"
                                 alt="Orochimaru" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Orochimaru</h2>
-                                <p class="card-text card-text--main">With a life-ambition to learn all of the world's secrets,
+                                <p class="filp-card__text filp-card__text--main">With a life-ambition to learn all of the world's secrets,
                                     Orochimaru seeks immortality so that he might live all of the lives necessary to
                                     accomplish his task. After being caught red-handed performing unethical
                                     experiments on his fellow citizens for the sake of this immortality</p>
@@ -2177,16 +2176,16 @@
                 <!-- Kakuzu card start-->
 
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kakuzu</h2>
-                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/1/14242/826300-300px_kakuzu.png"
+                            <img class="flip-card__image" src="https://www.giantbomb.com/a/uploads/scale_small/1/14242/826300-300px_kakuzu.png"
                                 alt="Kakuzu" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Kakuzu</h2>
-                                <p class="card-text card-text--main">Kakuzu is a member of the criminal organization known as
+                                <p class="filp-card__text filp-card__text--main">Kakuzu is a member of the criminal organization known as
                                     Akatsuki. He is the accountant for the Akatsuki which makes him obsessed
                                     with money, he also possesses five hearts. He once fought the first hokage
                                     Hashirama and lost. He is a former shinobi from the village hidden in the
@@ -2199,18 +2198,18 @@
 
                 <!-- Kurama card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kurama</h2>
 
-                            <img class="img_card" src="https://www.pngplay.com/wp-content/uploads/12/Kurama-PNG-Images-HD.png"
+                            <img class="flip-card__image" src="https://www.pngplay.com/wp-content/uploads/12/Kurama-PNG-Images-HD.png"
                                 alt="Kurama" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Kurama</h2>
 
-                                <p class="card-text card-text--main">Kurama (九喇嘛, Kurama), more commonly known as the
+                                <p class="filp-card__text filp-card__text--main">Kurama (九喇嘛, Kurama), more commonly known as the
                                     Nine-Tails (九尾, Kyūbi),
                                     was one of the nine tailed beasts.
                                     After being sealed into Naruto Uzumaki, Kurama attempts to maintain its
@@ -2227,18 +2226,18 @@
 
                 <!-- [Teuchi] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Teuchi</h2>
-                            <img class="img_card" src="https://static.wikia.nocookie.net/naruto/images/d/d6/Teuchi_Infobox.png"
+                            <img class="flip-card__image" src="https://static.wikia.nocookie.net/naruto/images/d/d6/Teuchi_Infobox.png"
                                 alt="Teuchi" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <h2 class="card-title">Teuchi</h2>
-                            <p class="card-text card-text--main">As a teenager 34 years before the Fourth Shinobi World
+                            <p class="filp-card__text filp-card__text--main">As a teenager 34 years before the Fourth Shinobi World
                                 War, Teuchi devoted his life to making
                                 ramen. More than a decade later, he had a daughter called Ayame.</p>
-                            <p class="card-text">Teuchi is a very kind and jovial man. Often seen smiling, he and Ayame
+                            <p class="filp-card__text">Teuchi is a very kind and jovial man. Often seen smiling, he and Ayame
                                 have always treated Naruto Uzumaki well,
                                 considering him their best customer, sometimes even giving him free
                                 ramen on special occasions.
@@ -2250,15 +2249,15 @@
 
                 <!-- Pain card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Pain </h2>
-                            <img class="img_card" src="https://fictionhorizon.com/wp-content/uploads/2021/09/pain-quotes.jpg" alt=Pain
+                            <img class="flip-card__image" src="https://fictionhorizon.com/wp-content/uploads/2021/09/pain-quotes.jpg" alt=Pain
                                 height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <h2 class="card-title">Pain </h2>
-                            <p class="card-text card-text--main">
+                            <p class="filp-card__text filp-card__text--main">
 
                                 Pain is the recognised leader of Akatsuki and leader of Amegakure. He
                                 wields the legendary Rinnegan and refers to himself as a god. His real
@@ -2274,15 +2273,15 @@
 
                 <!-- Ebizo card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Ebizo</h2>
-                            <img class="img_card" src="./Images/ebiZoo.jpg" alt="Ebizo" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/ebiZoo.jpg" alt="Ebizo" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Ebizo</h2>
-                                <p class="card-text card-text--main">
+                                <p class="filp-card__text filp-card__text--main">
                                     Ebizō (エビゾウ, Ebizō), called Honoured Grandfather Ebizō (エビゾウジイ様,
                                     Ebizō-jiisama) by the Suna villagers, is highly revered in
                                     Sunagakure. He and his older sister, Chiyo, are known as the
@@ -2296,17 +2295,17 @@
 
                 <!-- Nekobaa card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Nekobaa</h2>
 
-                            <img class="img_card" src="./Images/Nekobaa.jpg" alt="Nekobaa" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/Nekobaa.jpg" alt="Nekobaa" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Nekobaa</h2>
 
-                                <p class="card-text card-text--main">Nekobaa (猫バア, Nekobaa, English TV: Granny Cat,
+                                <p class="filp-card__text filp-card__text--main">Nekobaa (猫バア, Nekobaa, English TV: Granny Cat,
                                     literally meaning: Grandma Cat) is an old woman who lives in an
                                     abandoned city together with her granddaughter, Tamaki. She runs
                                     a supplies shop that the Uchiha clan used to use. She lives with
@@ -2318,17 +2317,17 @@
                 <!-- Nekobaa card end-->
                 <!-- Jūzō Biwa card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Jūzō Biwa</h2>
 
-                            <img class="img_card" src="./Images/J3F_Biwa.png" alt="Nekobaa" height="300px" width="300px">
+                            <img class="flip-card__image" src="./Images/J3F_Biwa.png" alt="Nekobaa" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
+                        <div class="flip-card__back">
                             <div class="card-body">
                                 <h2 class="card-title">Jūzō Biwa</h2>
 
-                                <p class="card-text card-text--main">Jūzō Biwa (枇杷十蔵, Biwa Jūzō) was a jōnin
+                                <p class="filp-card__text filp-card__text--main">Jūzō Biwa (枇杷十蔵, Biwa Jūzō) was a jōnin
                                     from Kirigakure and a member of the Seven Ninja Swordsmen of
                                     the Mist. In the anime, Jūzō deserted his village and became
                                     a member of Akatsuki, where he was partnered with Itachi
@@ -2339,14 +2338,13 @@
                 </div>
                 <!-- Jūzō Biwa card end-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Kisame Hoshigaki</h2>
-                            <img class="img_card" src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="300px" width="300px"
-                               >
+                            <img class="flip-card__image" src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text">Kisame Hoshigaki (干柿 鬼鮫, Hoshigaki Kisame) is a former ninja
+                        <div class="flip-card__back">
+                            <p class="filp-card__text">Kisame Hoshigaki (干柿 鬼鮫, Hoshigaki Kisame) is a former ninja
                                 of Kirigakure and partnered to Itachi Uchiha, having a
                                 unique appearance with pale blue skin, a gill-like facial
                                 structure, and sharp triangular teeth. While he was loyal to
@@ -2363,14 +2361,14 @@
 
                      <!-- Rasa card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Rasa</h2>
-                            <img class="img_card" src="Images\Rasa.jpg"
+                            <img class="flip-card__image" src="Images\Rasa.jpg"
                                 alt='Rasa' height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">Rasa (羅砂, Rasa) was the Fourth Kazekage (四代目風影, Yondaime Kazekage, literally meaning: Fourth Wind Shadow) of Sunagakure. Renowned for his ability to use Gold Dust, Rasa's reign as Kazekage was marked by his frequent quelling of rampages by the One-Tailed Shukaku, which he had sealed into his youngest son, Gaara.Rasa was a very powerful shinobi, as evidenced by his title of Kazekage. He could even subdue a fully released tailed beast like Shukaku. The prospect of his retaliation was enough to keep a great group of Iwa-nin from sparking a conflict at the Land of Wind's border.He was shown to be quite observant, pinpointing Gaara's Third Eye that was spying on him and the other reincarnated Kage after Mū sensed his chakra. </p>
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">Rasa (羅砂, Rasa) was the Fourth Kazekage (四代目風影, Yondaime Kazekage, literally meaning: Fourth Wind Shadow) of Sunagakure. Renowned for his ability to use Gold Dust, Rasa's reign as Kazekage was marked by his frequent quelling of rampages by the One-Tailed Shukaku, which he had sealed into his youngest son, Gaara.Rasa was a very powerful shinobi, as evidenced by his title of Kazekage. He could even subdue a fully released tailed beast like Shukaku. The prospect of his retaliation was enough to keep a great group of Iwa-nin from sparking a conflict at the Land of Wind's border.He was shown to be quite observant, pinpointing Gaara's Third Eye that was spying on him and the other reincarnated Kage after Mū sensed his chakra. </p>
                         </div>
                     </div>
                 </div>
@@ -2379,14 +2377,14 @@
                 
             <!-- [Gold and Silver Brothers] card start-->
             <div class="flip-card">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
+                <div class="flip-card__inner">
+                    <div class="flip-card__front">
                         <h2 class="card-title">Gold and Silver Brothers</h2>
-                        <img class="img_card" src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px" width="300px">
+                        <img class="flip-card__image" src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px" width="300px">
                     </div>
-                    <div class="flip-card-back">
-                        <p class="card-text card-text--main">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
-                        <p class="card-text">They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
+                    <div class="flip-card__back">
+                        <p class="filp-card__text filp-card__text--main">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
+                        <p class="filp-card__text">They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
    </div>
                     </div>
                 </div>
@@ -2395,18 +2393,18 @@
 
                 <!-- [Gold and Silver Brothers] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Gold and Silver Brothers</h2>
-                            <img class="img_card" src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px"
+                            <img class="flip-card__image" src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px"
                                 width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The Gold and Silver Brothers (金銀兄弟, Kingin
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The Gold and Silver Brothers (金銀兄弟, Kingin
                                 Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no
                                 Hikari), were two infamous shinobi from Kumogakure, that
                                 were distantly related to the Sage of Six Paths.</p>
-                            <p class="card-text">They were the ones who attacked Tobirama, the Second Hokage,
+                            <p class="filp-card__text">They were the ones who attacked Tobirama, the Second Hokage,
                                 and A, the Second Raikage, during an alliance meeting and
                                 tried to steal the Nine-tails for themselves. Later they
                                 were eaten by the Nine-Tailed Demon Fox and the brothers ate
@@ -2423,17 +2421,16 @@
 
                 <!-- [Asura Path of Pain] card start-->
                 <div class="flip-card">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
+                    <div class="flip-card__inner">
+                        <div class="flip-card__front">
                             <h2 class="card-title">Asura Path of Pain</h2>
-                            <img class="img_card" src="Images/asura-path-pain.jpg" alt="Asura Path of Pain" height="300px" width="300px"
-                               >
+                            <img class="flip-card__image" src="Images/asura-path-pain.jpg" alt="Asura Path of Pain" height="300px" width="300px">
                         </div>
-                        <div class="flip-card-back">
-                            <p class="card-text card-text--main">The Asura Path (修羅道) grants the user the
+                        <div class="flip-card__back">
+                            <p class="filp-card__text filp-card__text--main">The Asura Path (修羅道) grants the user the
                                 ability to augment their own body to summon mechanised
                                 armour and various ballistic and mechanical weaponry.</p>
-                            <p class="card-text">Through the Asura Path, the user is able to form up to four
+                            <p class="filp-card__text">Through the Asura Path, the user is able to form up to four
                                 additional arms and two additional faces, as well as a
                                 folded, serrated blade-like sash around their waist.</p>
                         </div>
@@ -2444,16 +2441,16 @@
 	            <!--[Asura Path of Pain] card end-->
           <!-- [A (First Raikage)] card start-->
               <div class="flip-card">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
+                <div class="flip-card__inner">
+                    <div class="flip-card__front">
                         <h2 class="card-title">[A (First Raikage)]</h2>
-                        <img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/7/70/A.png/revision/latest/scale-to-width-down/1000?cb=20141016130545 alt="A (First Raikage)" height="300px" width="300px">
+                        <img class="flip-card__image" src=https://static.wikia.nocookie.net/naruto/images/7/70/A.png/revision/latest/scale-to-width-down/1000?cb=20141016130545 alt="A (First Raikage)" height="300px" width="300px">
                     </div>
-                    <div class="flip-card-back">
-                        <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the First Raikage (初代雷影, Shodai Raikage, literally meaning:
+                    <div class="flip-card__back">
+                        <p class="filp-card__text filp-card__text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the First Raikage (初代雷影, Shodai Raikage, literally meaning:
                              First or Founding Lightning Shadow) who founded Kumogakure in the Land of Lightning.During his leadership in the early days of Kumogakure after the Warring States Period,
                               A presumably sent the Gold and Silver Brothers to capture the Nine-Tails, a task at which they ultimately failed.
-                        <p class="card-text">While not much was seen of his personality, A did seemingly have a verbal tic, ending his sentences with "yo" (よ).
+                        <p class="filp-card__text">While not much was seen of his personality, A did seemingly have a verbal tic, ending his sentences with "yo" (よ).
                             He also seemed to have a habit of folding his arms. He was a prideful man and held the idea that shinobi shouldn't lower their heads so easily.
                             A had a strong will to protect Kumogakure, something he passed down to his successor.</p>
                     </div>
@@ -2462,38 +2459,38 @@
             <!--[A (First Raikage)] card end-->
             <!-- [A (Second Raikage)] card start-->
             <div class="flip-card">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
+                <div class="flip-card__inner">
+                    <div class="flip-card__front">
                         <h2 class="card-title">[A (Second Raikage)]</h2>
-                        <img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/3/3f/2nd_Raikage.png/revision/latest/scale-to-width-down/1000?cb=20211214203620 alt="A (Second Raikage)" height="300px" width="300px">
+                        <img class="flip-card__image" src=https://static.wikia.nocookie.net/naruto/images/3/3f/2nd_Raikage.png/revision/latest/scale-to-width-down/1000?cb=20211214203620 alt="A (Second Raikage)" height="300px" width="300px">
                     </div>
-                    <div class="flip-card-back">
-                        <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Second Raikage (二代目雷影, Nidaime Raikage, literally meaning: Second Lightning Shadow) of Kumogakure.
+                    <div class="flip-card__back">
+                        <p class="filp-card__text filp-card__text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Second Raikage (二代目雷影, Nidaime Raikage, literally meaning: Second Lightning Shadow) of Kumogakure.
                             Throughout his reign he worked hard towards building peace between the other hidden villages.Before becoming the Second Raikage, he had a long tenure as the First Raikage's guard. During his service, he accompanied him to the first ever Five Kage Summit. 
                             There he stood behind the First watching diligently as the proceedings unfolded.
                             Eventually, his long service and dedication earned him the appointment of Second Raikage.
                              During his tenure, A entered Kumogakure into a formal alliance with Konohagakure, however, during the ceremony both he, and the Second Hokage were ambushed by the Gold and Silver Brothers, who were attempting to stage a coup d'état.
                               It is unknown what happened to A, but the Hokage was said to have barely escaped with his life.Overall A's actions helped Kumogakure a lot in the way of achieving peace.
-                        <p class="card-text">A inherited the strong will of his predecessor to protect Kumogakure. He was also described as being friendly and intelligent, seen by his versed knowledge in politics</p>
+                        <p class="filp-card__text">A inherited the strong will of his predecessor to protect Kumogakure. He was also described as being friendly and intelligent, seen by his versed knowledge in politics</p>
                     </div>
                 </div>
             </div>
             <!--[A (Second Raikage)] card end-->
              <!-- [A (Third Raikage)] card start-->
              <div class="flip-card">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
+                <div class="flip-card__inner">
+                    <div class="flip-card__front">
                         <h2 class="card-title">[A (Third Raikage)]</h2>
-                        <img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/f/f5/Raikage3.png/revision/latest/scale-to-width-down/1000?cb=20160116123903 alt="A (Third Raikage)" height="300px" width="300px">
+                        <img class="flip-card__image" src=https://static.wikia.nocookie.net/naruto/images/f/f5/Raikage3.png/revision/latest/scale-to-width-down/1000?cb=20160116123903 alt="A (Third Raikage)" height="300px" width="300px">
                     </div>
-                    <div class="flip-card-back">
-                        <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Third Raikage (三代目雷影, Sandaime Raikage, literally meaning:
+                    <div class="flip-card__back">
+                        <p class="filp-card__text filp-card__text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Third Raikage (三代目雷影, Sandaime Raikage, literally meaning:
                              Third Lightning Shadow) of Kumogakure, renowned to be the greatest Raikage the village has ever had.
                              A's rule was punctuated by the berserk attacks of the Eight-Tails but as Kumogakure couldn't afford to dispose of such a valuable war deterrent, he was forced to look for a suitable jinchūriki in quick succession, after the conclusion of each rampage.
                              During one of these attacks, A fought the Eight-Tails alone, allowing his comrades to escape. Their battle resulted in A receiving a self-inflicted wound to the chest after he collapsed upon his own hand, which became his life's shame.
                              Since this event, he made it a personal duty to combat the Eight-Tails whenever its jinchūriki lost control, eventually making even his son become part of the group that supported him during these occurrences. 
                              He chose to seal the Eight-Tails in the Kohaku no Jōhei, resulting in his nephew's death, hoping that someone else would have more success in controlling it.
-                        <p class="card-text">A is a calm and seemingly level-headed person. He is also a man of honour as seen when he became outraged when Mū urges Ōnoki to take advantage of the Allied Shinobi Forces after it is disbanded, telling him that he wouldn't allow the alliance to become destroyed. 
+                        <p class="filp-card__text">A is a calm and seemingly level-headed person. He is also a man of honour as seen when he became outraged when Mū urges Ōnoki to take advantage of the Allied Shinobi Forces after it is disbanded, telling him that he wouldn't allow the alliance to become destroyed. 
                             He is also a very proud and caring individual who will readily use himself as a shield or "go-between" to protect his comrades. This was also exemplified when it was revealed that after he received a scar from fighting the Eight-Tails, not even his son asked him about it in detail, out of his respect for his father's pride.
                             A was also a firm believer of children being destined to surpass their parents, so much so he told his fellow Kage who were reincarnated not to worry about being forced to fight against their fellow shinobi as their children would be able to defeat them.</p>
                     </div>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Naruto Uzumaki</h2>
-                            <img src="./Images/naruto.png" alt="naruto" height="330px" width="300px">
+                            <img class="img_card" src="./Images/naruto.png" alt="naruto" height="330px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Naruto Uzumaki is the main protagonist in the popular manga and anime
@@ -136,7 +136,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Sasuke Uchiha</h2>
-                            <img src="./Images/Sasuke.png" alt="Sasuke Uchiha" height="350px" width="250px">
+                            <img class="img_card" src="./Images/Sasuke.png" alt="Sasuke Uchiha" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Sasuke Uchiha (うちはサスケ, Uchiha Sasuke) is one of the last surviving
@@ -156,8 +156,8 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Suigetsu</h2>
-                            <img src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px"
-                                class="img_card">
+                            <img class="img_card" src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px"
+                               >
 
                         </div>
                         <div class="flip-card-back">
@@ -184,7 +184,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Sai Yamanaka</h2>
-                            <img src="./Images/Sai_Infobox.png" alt="Sai" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Sai_Infobox.png" alt="Sai" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Sai Yamanaka (山中サイ, Yamanaka Sai) is the Anbu Chief of
@@ -207,7 +207,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Anko Mitarashi</h2>
-                            <img src="./Images/anko.jpg" alt="Anko Mitarashi" height="300px" width="300px">
+                            <img class="img_card" src="./Images/anko.jpg" alt="Anko Mitarashi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
 
@@ -230,7 +230,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Chiriku</h2>
-                            <img src="./Images/chiriku.jpg" alt="Chiriku" height="300px" width="300px">
+                            <img class="img_card" src="./Images/chiriku.jpg" alt="Chiriku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Chiriku is a Fire Temple monk, formerly a member of the “12 Guardian
@@ -253,7 +253,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ten Tails - Juubi</h2>
-                            <img src="./Images/ten tails.jpeg" alt="Ten Tails" height="300px" width="300px">
+                            <img class="img_card" src="./Images/ten tails.jpeg" alt="Ten Tails" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">This Ten-Tails (十尾, Jūbi) is the combined form of Kaguya Ōtsutsuki and
@@ -274,7 +274,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Eight Tails - Gyuki</h2>
-                            <img src="./Images/Gyuki-Eight-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
+                            <img class="img_card" src="./Images/Gyuki-Eight-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -297,7 +297,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Seven-Tails - Chomei</h2>
-                            <img src="./Images/Chomei-Seven-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
+                            <img class="img_card" src="./Images/Chomei-Seven-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -320,7 +320,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Asura</h2>
-                            <img src="./Images/Asura.png" alt="Asura" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Asura.png" alt="Asura" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Asura Ōtsutsuki (大筒木アシュラ, Ōtsutsuki Ashura) was the younger son of
@@ -342,7 +342,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Inuzuka Hana</h2>
-                            <img src="./Images/inuzuka_hana.jpg" alt="Inuzuka Hana" height="300px" width="300px">
+                            <img class="img_card" src="./Images/inuzuka_hana.jpg" alt="Inuzuka Hana" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hana is a kunoichi from Konoha village. She is Kiba's sister and
@@ -358,7 +358,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title"> Izumi Uchiha </h2>
-                            <img src="./Images/Izumi_Uchiha.jpg" alt="Izumi Uchiha" height="350px" width="380px">
+                            <img class="img_card" src="./Images/Izumi_Uchiha.jpg" alt="Izumi Uchiha" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Izumi was the daughter of Hazuki Uchiha. Unlike her mother, Izumi's
@@ -383,7 +383,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Fūka</h2>
-                            <img src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
+                            <img class="img_card" src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
@@ -405,7 +405,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Rôshi</h2>
-                            <img src="./Images/roshi.jpg" alt="Rôshi" height="300px" width="300px">
+                            <img class="img_card" src="./Images/roshi.jpg" alt="Rôshi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Rôshi was the last Jinchûriki of Yonbi, the 4-tailed demon. He was
@@ -424,7 +424,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Suigetsu</h2>
 
-                            <img src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">
@@ -447,7 +447,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Boruto Uzumaki</h2>
 
-                            <img src="./Images/boruto.jpg" alt="boruto" height="350px" width="380px">
+                            <img class="img_card" src="./Images/boruto.jpg" alt="boruto" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Boruto Uzumaki (うずまきボルト, Uzumaki Boruto) is a shinobi from
@@ -467,7 +467,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Uchiha Madara</h2>
-                            <img src="./Images/madara.jpg" alt="boruto" height="350px" width="380px">
+                            <img class="img_card" src="./Images/madara.jpg" alt="boruto" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">
@@ -493,7 +493,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ebisu</h2>
-                            <img src="./Images/Ebisu.png" alt=Ebisu height="300px" width="300px">
+                            <img class="img_card" src="./Images/Ebisu.png" alt=Ebisu height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Specializes in the private training of Ninja, and is
@@ -510,7 +510,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Yukimaru </h2>
 
-                            <img src="./Images/yukimaru.png" alt="Haku" height="350px" width="380px">
+                            <img class="img_card" src="./Images/yukimaru.png" alt="Haku" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Yukimaru is a young orphan who became one of Orochimaru's test
@@ -528,7 +528,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Yamato</h2>
-                            <img src="./Images/Yamato.png" alt=Yamato height="300px" width="300px">
+                            <img class="img_card" src="./Images/Yamato.png" alt=Yamato height="300px" width="300px">
 
                         </div>
                         <div class="flip-card-back">
@@ -549,7 +549,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Hanabi Hyuga</h2>
-                            <img src="./Images/Hanabi-Hyuga.webp" alt="Hanabi Hyuga" height="350px" width="380px">
+                            <img class="img_card" src="./Images/Hanabi-Hyuga.webp" alt="Hanabi Hyuga" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hanabi is the younger sister of Hinata. She plays an important role in
@@ -566,7 +566,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Tsunade</h2>
-                            <img src="Images/Tsunade.jpg" alt=Tsunade height="300px" width="300px">
+                            <img class="img_card" src="Images/Tsunade.jpg" alt=Tsunade height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Tsunade is a kunoichi from the Hidden Leaf Village and posses
@@ -602,7 +602,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Jirobo</h2>
-                            <img src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330799-jirobo.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330799-jirobo.jpg"
                                 alt=Kawaki height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -621,7 +621,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Hanare</h2>
-                            <img src="https://qph.fs.quoracdn.net/main-qimg-85fae3ac8ec01ad91d4a5304cf3a2b1a"
+                            <img class="img_card" src="https://qph.fs.quoracdn.net/main-qimg-85fae3ac8ec01ad91d4a5304cf3a2b1a"
                                 alt="Hanare" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -655,7 +655,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Fūka</h2>
-                            <img src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
+                            <img class="img_card" src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
@@ -677,7 +677,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Mizuki</h2>
-                            <img src="Images/Mizuki.png" alt="Mizuki" height="300px" width="300px">
+                            <img class="img_card" src="Images/Mizuki.png" alt="Mizuki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">The first-ever person whom Naruto faced in a battle in order to know
@@ -701,7 +701,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">The Demon Brothers</h2>
-                            <img src="Images/Naruto-Demon-Brothers.jpg" alt=[name of character] height="300px"
+                            <img class="img_card" src="Images/Naruto-Demon-Brothers.jpg" alt=[name of character] height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -730,7 +730,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Madara Uchiha</h2>
-                            <img src="Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
+                            <img class="img_card" src="Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
 
@@ -753,7 +753,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Tayuya</h2>
-                            <img src="./Images/tayuya.jpg" alt="Tayuya Image" height="300px" width="300px">
+                            <img class="img_card" src="./Images/tayuya.jpg" alt="Tayuya Image" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">A kunoichi from The Hidden Sound Village and a member of The Sound
@@ -771,7 +771,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Kagura</h2>
-                            <img src="https://www.giantbomb.com/a/uploads/scale_small/16/164924/2399930-kagura.png"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/16/164924/2399930-kagura.png"
                                 alt="Kagura" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -789,7 +789,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Tenten</h2>
-                            <img src="Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
+                            <img class="img_card" src="Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
 
@@ -806,7 +806,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Itachi Uchiha</h2>
-                            <img src="images/Itachi.png" alt="Itachi Uchiha" height="300px" width="300px">
+                            <img class="img_card" src="images/Itachi.png" alt="Itachi Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Itachi Uchiha is a fictional character in the Naruto manga and anime
@@ -827,7 +827,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Isaribi</h2>
-                            <img src="Images/Isaribi.jpg" alt="Isaribi" height="280px" width="400px">
+                            <img class="img_card" src="Images/Isaribi.jpg" alt="Isaribi" height="280px" width="400px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main"> Isaribi was a part sea creature whose charecter arc was similar to
@@ -848,7 +848,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kurama</h2>
 
-                            <img src="https://www.giantbomb.com/a/uploads/original/13/135472/2264772-narutoninjastorm3battle016.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/original/13/135472/2264772-narutoninjastorm3battle016.jpg"
                                 alt="Kurama" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -875,7 +875,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Hiashi Hyūga</h2>
-                            <img src="images/Hiashi_Hyuga.png" alt="Hiashi Hyuga" height="300px" width="300px">
+                            <img class="img_card" src="images/Hiashi_Hyuga.png" alt="Hiashi Hyuga" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hiashi Hyuga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
@@ -898,7 +898,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Bansai</h2>
 
-                            <img src="./Images/bansai.png" alt="Bansai" height="300px" width="300px">
+                            <img class="img_card" src="./Images/bansai.png" alt="Bansai" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Bansai is an elder ninja monk in the Fire Temple as well as the Head
@@ -916,7 +916,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Minato Namikaze</h2>
 
-                            <img src="Images/minatoNew.jpg" alt="Minato" height="300px" width="300px">
+                            <img class="img_card" src="Images/minatoNew.jpg" alt="Minato" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Minato Namikaze is a character in the Naruto universe. He is better
@@ -935,7 +935,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kawaki</h2>
 
-                            <img src="./Images/kawaki2.jpg" alt="kawaki" height="300px" width="300px">
+                            <img class="img_card" src="./Images/kawaki2.jpg" alt="kawaki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Kawaki (カワキ, Kawaki) is a tattooed youth who became a member of Kara
@@ -960,7 +960,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Eida</h2>
 
-                            <img src="./Images/eida.png" alt="Eida" height="350px" width="350px">
+                            <img class="img_card" src="./Images/eida.png" alt="Eida" height="350px" width="350px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">In his plot to kill Jigen, Amado heavily modified Eida, along with her
@@ -986,7 +986,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Daemon</h2>
 
-                            <img src="./Images/Daemon.webp" alt="Daemon" height="350px" width="350px">
+                            <img class="img_card" src="./Images/Daemon.webp" alt="Daemon" height="350px" width="350px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Daemon used to be a member of Kara.
@@ -1005,7 +1005,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Nagato Uzumaki</h2>
 
-                            <img src="./Images/nagato.png" alt="Nagato Uzumaki" height="350px" width="380px">
+                            <img class="img_card" src="./Images/nagato.png" alt="Nagato Uzumaki" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Nagato was known primarily under the alias of Pain. Nagato is the
@@ -1028,7 +1028,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">YAMATO</h2>
 
-                            <img src="./Images/yamato.png" alt="Nagato Uzumaki" height="350px" width="380px">
+                            <img class="img_card" src="./Images/yamato.png" alt="Nagato Uzumaki" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Seeing how pivotal of a role Kakashi played as the leader of Team Seven
@@ -1053,7 +1053,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hashirama Senju </h2>
 
-                            <img src=https://www.giantbomb.com/a/uploads/scale_small/3/33873/1727699-first_hokage.jpg
+                            <img class="img_card" src=https://www.giantbomb.com/a/uploads/scale_small/3/33873/1727699-first_hokage.jpg
                                 alt="Hashirama Senju image" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1078,7 +1078,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Yahiko </h2>
 
-                            <img src="./Images/Yahiko.png" alt="anko" height="350px" width="380px">
+                            <img class="img_card" src="./Images/Yahiko.png" alt="anko" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Yahiko (弥彦, Yahiko) was a shinobi from Amegakure. Alongside his fellow
@@ -1098,7 +1098,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Deidara</h2>
 
-                            <img src="./Images/deidara69.jpg" alt="Deidara" height="300px" width="300px">
+                            <img class="img_card" src="./Images/deidara69.jpg" alt="Deidara" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Deidara is a member of the Akatsuki group, Deidara was partnered with
@@ -1119,7 +1119,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Tsuande </h2>
 
-                            <img src="./Images/Tsunadexx.png" alt="anko" height="350px" width="380px">
+                            <img class="img_card" src="./Images/Tsunadexx.png" alt="anko" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Tsunade (綱手, Tsunade) is a descendant of the Senju and Uzumaki Clan,
@@ -1139,7 +1139,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">KIMIMARO</h2>
 
-                            <img src="./Images/kimimaro.png" alt="kimimaro" height="350px" width="380px">
+                            <img class="img_card" src="./Images/kimimaro.png" alt="kimimaro" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">
@@ -1157,7 +1157,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Zabuza</h2>
-                            <img src="https://www.giantbomb.com/a/uploads/scale_small/3/34651/3376238-zabuza.png"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/3/34651/3376238-zabuza.png"
                                 alt="Zabuza" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1179,7 +1179,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Haku </h2>
 
-                            <img src="./Images/Casual_Haku.png" alt="Haku" height="350px" width="380px">
+                            <img class="img_card" src="./Images/Casual_Haku.png" alt="Haku" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Haku was an orphan from the Land of Water, and a descendant of the Yuki
@@ -1201,7 +1201,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Tonton </h2>
 
-                            <img src="./Images/Tonton.png" alt="Tonton" height="350px" width="380px">
+                            <img class="img_card" src="./Images/Tonton.png" alt="Tonton" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Tonton is Tsunade's ninja pig, often kept in the care of Shizune.</p>
@@ -1224,7 +1224,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Sand Siblings</h2>
 
-                            <img src="./Images/sand siblings.jpeg" alt="Sand-Siblings" height="350px" width="250px">
+                            <img class="img_card" src="./Images/sand siblings.jpeg" alt="Sand-Siblings" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">
@@ -1250,7 +1250,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hidan</h2>
 
-                            <img src="./Images/Hidan.png" alt="Hidan" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Hidan.png" alt="Hidan" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hidan is an S-rank missing-nin who defected from Yugakure and later
@@ -1273,7 +1273,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Sakon & Ukon</h2>
 
-                            <img src="./Images/sakon_ukon.jpg" alt="sakon and ukon" height="350px" width="250px">
+                            <img class="img_card" src="./Images/sakon_ukon.jpg" alt="sakon and ukon" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">
@@ -1301,7 +1301,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Zabuza</h2>
 
-                            <img src="https://www.giantbomb.com/a/uploads/square_small/0/534/178998-zabuza.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/square_small/0/534/178998-zabuza.jpg"
                                 alt=Zabuza height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1323,7 +1323,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Tenten</h2>
 
-                            <img src="./Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">In the Konoha 11, which consists of many of Naruto's peers in Team
@@ -1347,7 +1347,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Might Guy</h2>
 
-                            <img src="./Images/GuyGawd.png" alt="Might Guy" height="300px" width="300px">
+                            <img class="img_card" src="./Images/GuyGawd.png" alt="Might Guy" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Might Guy (マイト・ガイ, Maito Gai) is a jōnin of Konohagakure. A master of
@@ -1368,7 +1368,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Asuma Sarutobi</h2>
 
-                            <img src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
+                            <img class="img_card" src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1395,7 +1395,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hidan</h2>
 
-                            <img src="./Images/Hidan.jpg" alt="Hidan" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Hidan.jpg" alt="Hidan" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hidan (飛段) is the immortal, foul-mouthed, and sadomasochistic partner
@@ -1422,7 +1422,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kakashi Hatake</h2>
 
-                            <img src="./Images/kakashi.jpg" alt="Naruto Uzumaki" height="300px" width="300px">
+                            <img class="img_card" src="./Images/kakashi.jpg" alt="Naruto Uzumaki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
@@ -1445,7 +1445,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Fugaku</h2>
 
-                            <img src="./Images/fugaku.jpeg" alt="Fugaku" height="300px" width="300px">
+                            <img class="img_card" src="./Images/fugaku.jpeg" alt="Fugaku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Fugaku Uchiha (うちはフガク, Uchiha Fugaku) was a shinobi of Konohagakure. He
@@ -1470,7 +1470,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Inari</h2>
 
-                            <img src="./Images/inari.png" alt="Fugaku" height="300px" width="300px">
+                            <img class="img_card" src="./Images/inari.png" alt="Fugaku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
@@ -1491,7 +1491,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Third Raikage</h2>
 
-                            <img src="Images/Raikage3.png" alt="Fugaku" height="300px" width="300px">
+                            <img class="img_card" src="Images/Raikage3.png" alt="Fugaku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
@@ -1519,7 +1519,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Mikoto Uchiha</h2>
 
-                            <img src="https://wallpapercave.com/wp/wp4126361.png" alt="Mikoto" height="300px"
+                            <img class="img_card" src="https://wallpapercave.com/wp/wp4126361.png" alt="Mikoto" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1545,7 +1545,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Black Zetsu</h2>
 
-                            <img src="https://wallpapercave.com/wp/wp8345725.jpg" alt="BlackZetsu" height="300px"
+                            <img class="img_card" src="https://wallpapercave.com/wp/wp8345725.jpg" alt="BlackZetsu" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1578,7 +1578,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Mito Uzumaki</h2>
 
-                            <img src="./Images/MitoUzumaki.jpg" alt="Mito" height="300px" width="300px">
+                            <img class="img_card" src="./Images/MitoUzumaki.jpg" alt="Mito" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Mito Uzumaki (うずまきミト, Uzumaki Mito) was a kunoichi who originated from
@@ -1605,7 +1605,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Guren</h2>
 
-                            <img src="./Images/Guren.png" alt="Guren" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Guren.png" alt="Guren" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Guren (紅蓮, Guren) is a kunoichi from Otogakure and the leader of a
@@ -1631,7 +1631,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hanzō</h2>
 
-                            <img src="./Images/Hanzo-the-Salamander.jpg" alt="HANZO" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Hanzo-the-Salamander.jpg" alt="HANZO" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hanzō (半蔵, Hanzō), feared as Hanzō of the Salamander (山椒魚の半蔵, Sanshōuo
@@ -1658,7 +1658,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Konan</h2>
 
-                            <img src="https://cdnb.artstation.com/p/assets/images/images/029/881/599/medium/lilimonada-lilimon-konan.jpg?1598920736"
+                            <img class="img_card" src="https://cdnb.artstation.com/p/assets/images/images/029/881/599/medium/lilimonada-lilimon-konan.jpg?1598920736"
                                 alt="Konan" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1689,7 +1689,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kidomaru</h2>
 
-                            <img src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330403-kidomaru.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330403-kidomaru.jpg"
                                 alt="Kidomaru" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1707,7 +1707,7 @@
 			<div class="flip-card-inner">
 			    <div class="flip-card-front">
 				<h2 class="card-title">Karin</h2>
-				<img src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt=Karin height="300px" width="300px" class="img_card">
+				<img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt=Karin height="300px" width="300px">
 			    </div>
 			    <div class="flip-card-back">
 				<p class="card-text card-text--main">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
@@ -1725,7 +1725,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Ebisu Sensei</h2>
 
-                            <img src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
@@ -1753,7 +1753,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Tobirama Senju</h2>
 
-                            <img src="./Images/tobirama senju.png" alt="Ebisu" height="300px" width="300px">
+                            <img class="img_card" src="./Images/tobirama senju.png" alt="Ebisu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Tobirama Senju (千手扉間, Senju Tobirama) was a member of the renowned
@@ -1780,7 +1780,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hinata Hyuga</h2>
 
-                            <img src="./Images/hinata.jpeg" alt="Hinata" height="300px" width="300px">
+                            <img class="img_card" src="./Images/hinata.jpeg" alt="Hinata" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hinata, the eldest of Hiashi Hyuga's two children, is raised as the
@@ -1803,7 +1803,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hiashi Hyuga</h2>
 
-                            <img src="./Images/hiashi.jpeg" alt="Hiashi" height="300px" width="300px">
+                            <img class="img_card" src="./Images/hiashi.jpeg" alt="Hiashi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
@@ -1827,7 +1827,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Asuma Sarutobi</h2>
 
-                            <img src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
+                            <img class="img_card" src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1857,7 +1857,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Choza Akimichi</h2>
 
-                            <img src="./Images/choza_akimichi.png" alt="Choza Akimichi" height="300px" width="300px">
+                            <img class="img_card" src="./Images/choza_akimichi.png" alt="Choza Akimichi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Choza Akimichi (秋道チョウザ, Akimichi Chōza) is a jōnin of Konohagakure and
@@ -1874,7 +1874,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Madara Uchiha</h2>
 
-                            <img src="./Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
+                            <img class="img_card" src="./Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the
@@ -1895,7 +1895,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Izuna Uchiha</h2>
 
-                            <img src="./Images/Izuna_Uchiha.png" alt="Madara Uchiha" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Izuna_Uchiha.png" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Izuna Uchiha (うちはイズナ, Uchiha Izuna) was a shinobi of the Uchiha clan.
@@ -1909,7 +1909,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hashirama Senju</h2>
 
-                            <img src="./Images/hashirama.jpg" alt="Hashirama Senju" height="300px" width="300px">
+                            <img class="img_card" src="./Images/hashirama.jpg" alt="Hashirama Senju" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">The First hokage, leader of the Senju clan, one of the founders of
@@ -1928,7 +1928,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kaguya Otsutsuki</h2>
 
-                            <img src="./Images/Kaguya_Ōtsutsuki.png" alt=" " height="300px" width="300px">
+                            <img class="img_card" src="./Images/Kaguya_Ōtsutsuki.png" alt=" " height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Kaguya was the originator of shinobi in the world in which Naruto takes
@@ -1952,7 +1952,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Killer Bee</h2>
-                            <img src="./Images/KillerBee.png" alt="Killer Bee" height="300px" width="300px">
+                            <img class="img_card" src="./Images/KillerBee.png" alt="Killer Bee" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Killer B is a major supporting character in the anime and manga Naruto
@@ -1974,7 +1974,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Gamabunta</h2>
 
-                            <img src="./Images/Gamabunta.png" alt="Gamabunta" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Gamabunta.png" alt="Gamabunta" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Gamabunta is a grumpy, stubborn and highly apathetic toad. He was
@@ -1993,7 +1993,7 @@
                             <h2 class="card-title">Juubi</h2>
 
 
-                            <img src="https://i.pinimg.com/originals/88/c5/35/88c53577f0186691253c551c5f34170a.jpg"
+                            <img class="img_card" src="https://i.pinimg.com/originals/88/c5/35/88c53577f0186691253c551c5f34170a.jpg"
 
                                 alt="Juubi" height="300px" width="300px">
                         </div>
@@ -2016,7 +2016,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Matatabi</h2>
 
-                            <img src="./Images/matatabi.png" alt="Matatabi" height="300px" width="300px">
+                            <img class="img_card" src="./Images/matatabi.png" alt="Matatabi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">Matatabi also known as Two-Tails, is one of the nine tailed
@@ -2039,7 +2039,7 @@
 
                             <h2 class="card-title">Obito Uchiha </h2>
 
-                            <img src="https://wallpaperaccess.com/full/5536097.jpg" alt=Obito height="300px"
+                            <img class="img_card" src="https://wallpaperaccess.com/full/5536097.jpg" alt=Obito height="300px"
                                 width="300px">
 
                         </div>
@@ -2078,7 +2078,7 @@
 
                             <h2 class="card-title">Rin Nohara </h2>
 
-                            <img src="Images/Rin_Nohara.jpg" alt=Rin height="300px" width="300px">
+                            <img class="img_card" src="Images/Rin_Nohara.jpg" alt=Rin height="300px" width="300px">
 
                         </div>
 
@@ -2105,7 +2105,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Jiraiya</h2>
 
-                            <img src="https://www.giantbomb.com/a/uploads/scale_super/9/95613/2225257-jiraiya.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_super/9/95613/2225257-jiraiya.jpg"
                                 alt=Jiraiya height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2133,7 +2133,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Iruka Umino</h2>
 
-                            <img src="https://www.giantbomb.com/a/uploads/square_small/1/17433/595228-iruka.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/square_small/1/17433/595228-iruka.jpg"
                                 alt="Iruka Umino" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2155,7 +2155,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Orochimaru</h2>
-                            <img src="https://www.giantbomb.com/a/uploads/square_medium/0/5892/482861-naruto_orochi0244.jpg"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/square_medium/0/5892/482861-naruto_orochi0244.jpg"
                                 alt="Orochimaru" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2180,7 +2180,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Kakuzu</h2>
-                            <img src="https://www.giantbomb.com/a/uploads/scale_small/1/14242/826300-300px_kakuzu.png"
+                            <img class="img_card" src="https://www.giantbomb.com/a/uploads/scale_small/1/14242/826300-300px_kakuzu.png"
                                 alt="Kakuzu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2203,7 +2203,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kurama</h2>
 
-                            <img src="https://www.pngplay.com/wp-content/uploads/12/Kurama-PNG-Images-HD.png"
+                            <img class="img_card" src="https://www.pngplay.com/wp-content/uploads/12/Kurama-PNG-Images-HD.png"
                                 alt="Kurama" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2230,7 +2230,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Teuchi</h2>
-                            <img src="https://static.wikia.nocookie.net/naruto/images/d/d6/Teuchi_Infobox.png"
+                            <img class="img_card" src="https://static.wikia.nocookie.net/naruto/images/d/d6/Teuchi_Infobox.png"
                                 alt="Teuchi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2253,7 +2253,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Pain </h2>
-                            <img src="https://fictionhorizon.com/wp-content/uploads/2021/09/pain-quotes.jpg" alt=Pain
+                            <img class="img_card" src="https://fictionhorizon.com/wp-content/uploads/2021/09/pain-quotes.jpg" alt=Pain
                                 height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2277,7 +2277,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ebizo</h2>
-                            <img src="./Images/ebiZoo.jpg" alt="Ebizo" height="300px" width="300px">
+                            <img class="img_card" src="./Images/ebiZoo.jpg" alt="Ebizo" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <div class="card-body">
@@ -2300,7 +2300,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Nekobaa</h2>
 
-                            <img src="./Images/Nekobaa.jpg" alt="Nekobaa" height="300px" width="300px">
+                            <img class="img_card" src="./Images/Nekobaa.jpg" alt="Nekobaa" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <div class="card-body">
@@ -2322,7 +2322,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Jūzō Biwa</h2>
 
-                            <img src="./Images/J3F_Biwa.png" alt="Nekobaa" height="300px" width="300px">
+                            <img class="img_card" src="./Images/J3F_Biwa.png" alt="Nekobaa" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <div class="card-body">
@@ -2342,8 +2342,8 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Kisame Hoshigaki</h2>
-                            <img src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="300px" width="300px"
-                                class="img_card">
+                            <img class="img_card" src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="300px" width="300px"
+                               >
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kisame Hoshigaki (干柿 鬼鮫, Hoshigaki Kisame) is a former ninja
@@ -2366,7 +2366,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Rasa</h2>
-                            <img src="Images\Rasa.jpg"
+                            <img class="img_card" src="Images\Rasa.jpg"
                                 alt='Rasa' height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2382,7 +2382,7 @@
                 <div class="flip-card-inner">
                     <div class="flip-card-front">
                         <h2 class="card-title">Gold and Silver Brothers</h2>
-                        <img src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px" width="300px" class="img_card">
+                        <img class="img_card" src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px" width="300px">
                     </div>
                     <div class="flip-card-back">
                         <p class="card-text card-text--main">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
@@ -2398,8 +2398,8 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Gold and Silver Brothers</h2>
-                            <img src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px"
-                                width="300px" class="img_card">
+                            <img class="img_card" src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px"
+                                width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">The Gold and Silver Brothers (金銀兄弟, Kingin
@@ -2426,8 +2426,8 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Asura Path of Pain</h2>
-                            <img src="Images/asura-path-pain.jpg" alt="Asura Path of Pain" height="300px" width="300px"
-                                class="img_card">
+                            <img class="img_card" src="Images/asura-path-pain.jpg" alt="Asura Path of Pain" height="300px" width="300px"
+                               >
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text card-text--main">The Asura Path (修羅道) grants the user the
@@ -2447,7 +2447,7 @@
                 <div class="flip-card-inner">
                     <div class="flip-card-front">
                         <h2 class="card-title">[A (First Raikage)]</h2>
-                        <img src=https://static.wikia.nocookie.net/naruto/images/7/70/A.png/revision/latest/scale-to-width-down/1000?cb=20141016130545 alt="A (First Raikage)" height="300px" width="300px" class="img_card">
+                        <img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/7/70/A.png/revision/latest/scale-to-width-down/1000?cb=20141016130545 alt="A (First Raikage)" height="300px" width="300px">
                     </div>
                     <div class="flip-card-back">
                         <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the First Raikage (初代雷影, Shodai Raikage, literally meaning:
@@ -2465,7 +2465,7 @@
                 <div class="flip-card-inner">
                     <div class="flip-card-front">
                         <h2 class="card-title">[A (Second Raikage)]</h2>
-                        <img src=https://static.wikia.nocookie.net/naruto/images/3/3f/2nd_Raikage.png/revision/latest/scale-to-width-down/1000?cb=20211214203620 alt="A (Second Raikage)" height="300px" width="300px" class="img_card">
+                        <img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/3/3f/2nd_Raikage.png/revision/latest/scale-to-width-down/1000?cb=20211214203620 alt="A (Second Raikage)" height="300px" width="300px">
                     </div>
                     <div class="flip-card-back">
                         <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Second Raikage (二代目雷影, Nidaime Raikage, literally meaning: Second Lightning Shadow) of Kumogakure.
@@ -2484,7 +2484,7 @@
                 <div class="flip-card-inner">
                     <div class="flip-card-front">
                         <h2 class="card-title">[A (Third Raikage)]</h2>
-                        <img src=https://static.wikia.nocookie.net/naruto/images/f/f5/Raikage3.png/revision/latest/scale-to-width-down/1000?cb=20160116123903 alt="A (Third Raikage)" height="300px" width="300px" class="img_card">
+                        <img class="img_card" src=https://static.wikia.nocookie.net/naruto/images/f/f5/Raikage3.png/revision/latest/scale-to-width-down/1000?cb=20160116123903 alt="A (Third Raikage)" height="300px" width="300px">
                     </div>
                     <div class="flip-card-back">
                         <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Third Raikage (三代目雷影, Sandaime Raikage, literally meaning:

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                             <img src="./Images/naruto.png" alt="naruto" height="330px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Naruto Uzumaki is the main protagonist in the popular manga and anime
+                            <p class="card-text card-text--main">Naruto Uzumaki is the main protagonist in the popular manga and anime
                                 series Naruto. He is a cheerful, hyperactive, strong-willed, and occasionally
                                 simple-minded young shinobi from the village of Konoha (or Leaf Village).</p>
                             <p class="card-text">Since Naruto has the Nine Tails Fox sealed inside him, he is able to use the Fox's
@@ -139,7 +139,7 @@
                             <img src="./Images/Sasuke.png" alt="Sasuke Uchiha" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Sasuke Uchiha (うちはサスケ, Uchiha Sasuke) is one of the last surviving
+                            <p class="card-text card-text--main">Sasuke Uchiha (うちはサスケ, Uchiha Sasuke) is one of the last surviving
                                 members of Konohagakure's Uchiha clan. After his older brother, Itachi, slaughtered
                                 their clan, Sasuke made it his mission in life to avenge them by killing
                                 Itachi. He is added to Team 7 upon becoming a ninja and, through competition with his
@@ -162,7 +162,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 Suigetsu was a member of Sasuke's renegade group consisting of himself, Suigetsu, Karin,
                                 and Jugo. Of the quartet, Suigetsu was the self-styled comedian. He had plenty of
                                 sarcastic lines and made every effort he could to get under Karin's skin.
@@ -187,7 +187,7 @@
                             <img src="./Images/Sai_Infobox.png" alt="Sai" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Sai Yamanaka (山中サイ, Yamanaka Sai) is the Anbu Chief of
+                            <p class="card-text card-text--main">Sai Yamanaka (山中サイ, Yamanaka Sai) is the Anbu Chief of
                                 Konohagakure's Yamanaka clan. Prior to this, he was a Root member.
                                 As per standard Root training, Sai was conditioned to remove all emotions and as such,
                                 had difficulty connecting with others. When he is added to Team Kakashi as a replacement
@@ -211,7 +211,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">The proctor of the survival leg of the Chuunin exams, she goes through
+                            <p class="card-text card-text--main">The proctor of the survival leg of the Chuunin exams, she goes through
                                 her enemies like a blazing inferno. She was once tutored by Orochimaru, but was
                                 abandoned by him when she refused to follow his evil path.
                                 Anko Mitarashi is a Jonin of the Hidden Leaf Village. She was a proctor of the survival
@@ -233,7 +233,7 @@
                             <img src="./Images/chiriku.jpg" alt="Chiriku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Chiriku is a Fire Temple monk, formerly a member of the “12 Guardian
+                            <p class="card-text card-text--main">Chiriku is a Fire Temple monk, formerly a member of the “12 Guardian
                                 Ninjas” of the Lord of the Fire Land. There he will meet Asuma Sarutobi, son of the
                                 third Hokage. Their mission was to escort and protect the Daimyo of the Land of
                                 Fire.</p>
@@ -256,7 +256,7 @@
                             <img src="./Images/ten tails.jpeg" alt="Ten Tails" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">This Ten-Tails (十尾, Jūbi) is the combined form of Kaguya Ōtsutsuki and
+                            <p class="card-text card-text--main">This Ten-Tails (十尾, Jūbi) is the combined form of Kaguya Ōtsutsuki and
                                 the God Tree, created to reclaim the chakra inherited by her sons, Hagoromo and Hamura.
                                 It is regarded as the progenitor of chakra, and is tied to the legend of the Sage of Six
                                 Paths and the birth of shinobi. To end the beast's rampage, the Sage became the
@@ -278,7 +278,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Gyuki was sold to the Hidden Cloud village along with Matatabi, but the
+                            <p class="card-text card-text--main">Gyuki was sold to the Hidden Cloud village along with Matatabi, but the
                                 nation struggled to find a Jinchuriki who could control it. One of these was Blue B, the
                                 nephew of the Third Raikage, but after Gyuki went on a rampage, the Raikage was
                                 forced to seal him away, causing his nephew's tragic death. Gyuki was ultimately sealed
@@ -301,7 +301,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Chomei was formerly sealed within Fu, a female ninja from the Hidden
+                            <p class="card-text card-text--main">Chomei was formerly sealed within Fu, a female ninja from the Hidden
                                 Waterfall, after being sold to the village by Hashirama. This was unusual, since the
                                 Waterfall isn't one of Naruto's five major nations, but were considered powerful enough
                                 to be included in the arrangement. Naruto flashbacks show each of the tailed beasts as
@@ -323,7 +323,7 @@
                             <img src="./Images/Asura.png" alt="Asura" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Asura Ōtsutsuki (大筒木アシュラ, Ōtsutsuki Ashura) was the younger son of
+                            <p class="card-text card-text--main">Asura Ōtsutsuki (大筒木アシュラ, Ōtsutsuki Ashura) was the younger son of
                                 Hagoromo Ōtsutsuki. Though not the obvious choice to most, he would go on to inherit his
                                 father's teachings, and as a result, would have to clash bitterly against his elder
                                 brother Indra. Asura is also credited with being the progenitor of both the Senju and
@@ -345,7 +345,7 @@
                             <img src="./Images/inuzuka_hana.jpg" alt="Inuzuka Hana" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hana is a kunoichi from Konoha village. She is Kiba's sister and
+                            <p class="card-text card-text--main">Hana is a kunoichi from Konoha village. She is Kiba's sister and
                                 Tsume's daughter</p>
                             <p class="card-text">Hana also specializes in animal medicine: she is a veterinarian. His companions are 3 dog
                                 brothers: Les Trois Frères Haimaru.</p>
@@ -361,7 +361,7 @@
                             <img src="./Images/Izumi_Uchiha.jpg" alt="Izumi Uchiha" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Izumi was the daughter of Hazuki Uchiha. Unlike her mother, Izumi's
+                            <p class="card-text card-text--main">Izumi was the daughter of Hazuki Uchiha. Unlike her mother, Izumi's
                                 father was not an Uchiha.During the Nine-Tailed Demon Fox's Attack, her father died
                                 while protecting her.From the grief brought on by his death, as well as feelings of
                                 guilt that he would not have died had Izumi been stronger,Izumi eventually awakened her
@@ -386,7 +386,7 @@
                             <img src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Fūka was portrayed as a seductive vixen as a way to lure her prey in
+                            <p class="card-text card-text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
                                 and kill them with an Execution by Kiss.</p>
                             <p class="card-text">She would further speed up the process by giving her targets a choice between a French or
                                 traditional kiss. Her most preferable victims were those with a natural affinity for
@@ -408,7 +408,7 @@
                             <img src="./Images/roshi.jpg" alt="Rôshi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Rôshi was the last Jinchûriki of Yonbi, the 4-tailed demon. He was
+                            <p class="card-text card-text--main">Rôshi was the last Jinchûriki of Yonbi, the 4-tailed demon. He was
                                 killed by Kisame Hoshigaki, a former member of the Akatsuki, who aimed to reunite all
                                 the Biju.</p>
                             <p class="card-text">Rôshi will be resurrected later during the Fourth Great Ninja War by Kabuto Yakushi. He
@@ -427,7 +427,7 @@
                             <img src="./Images/Suigetsu.jpeg" alt="Suigetsu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 Suigetsu was a member of Sasuke's renegade group consisting of himself, Suigetsu, Karin,
                                 and Jugo. Of the quartet, Suigetsu was the self-styled comedian. He had plenty of
                                 sarcastic lines and made every effort he could to get under Karin's skin.
@@ -450,7 +450,7 @@
                             <img src="./Images/boruto.jpg" alt="boruto" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Boruto Uzumaki (うずまきボルト, Uzumaki Boruto) is a shinobi from
+                            <p class="card-text card-text--main">Boruto Uzumaki (うずまきボルト, Uzumaki Boruto) is a shinobi from
                                 Konohagakure's Uzumaki Clan and a direct descendant of the Hyūga clan through his
                                 mother. Initially nonchalant in his duties as a member of Team 7 and resentful of his
                                 father and the office of Hokage because it left him with no time for his family; Boruto
@@ -470,7 +470,7 @@
                             <img src="./Images/madara.jpg" alt="boruto" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the Uchiha clan.
                                 He founded Konohagakure alongside his childhood friend and rival, Hashirama Senju, with
                                 the intention of beginning an era of peace.
@@ -496,7 +496,7 @@
                             <img src="./Images/Ebisu.png" alt=Ebisu height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Specializes in the private training of Ninja, and is
+                            <p class="card-text card-text--main">Specializes in the private training of Ninja, and is
                                 often referred to as being a closet pervert. He is one of the sensei who's trained
                                 Konohamaru.</p>
                         </div>
@@ -513,7 +513,7 @@
                             <img src="./Images/yukimaru.png" alt="Haku" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Yukimaru is a young orphan who became one of Orochimaru's test
+                            <p class="card-text card-text--main">Yukimaru is a young orphan who became one of Orochimaru's test
                                 subjects, due to his ability to partially control the Three-Tails.</p>
                             <p class="card-text">Yukimaru lived with his mother in a village that was attacked by Orochimaru's followers
                                 when Yukimaru was a child.</p>
@@ -532,7 +532,7 @@
 
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Yamato is a very discreet, cautious, careful and well prepared person.
+                            <p class="card-text card-text--main">Yamato is a very discreet, cautious, careful and well prepared person.
                                 He projects a calm, stoic demeanour in stressful situations. He takes his missions very
                                 seriously, even insisting on being referred to by whatever his current codename</p>
                             <p class="card-text">Yamato is one of the main supporting characters in the Naruto anime/manga series and the
@@ -552,7 +552,7 @@
                             <img src="./Images/Hanabi-Hyuga.webp" alt="Hanabi Hyuga" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hanabi is the younger sister of Hinata. She plays an important role in
+                            <p class="card-text card-text--main">Hanabi is the younger sister of Hinata. She plays an important role in
                                 The Last: Naruto the Movie. Her father is Hiashi Hyuga and is auntie to Hinata's
                                 children, Boruto and Himawari. Her cousin is Neji Hyuga.
                                 Naruto Uzumaki is her brother-in-law.</p>
@@ -569,7 +569,7 @@
                             <img src="Images/Tsunade.jpg" alt=Tsunade height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Tsunade is a kunoichi from the Hidden Leaf Village and posses
+                            <p class="card-text card-text--main">Tsunade is a kunoichi from the Hidden Leaf Village and posses
                                 Monstrous physical strength, extremely advanced healing and regenerative techniques,
                                 physician/surgeon
                                 level of knowledge of the human body and great Chakra control. At once formed part of
@@ -606,7 +606,7 @@
                                 alt=Kawaki height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">A ninja from The Hidden Sound Village and member of The Sound Five.he
+                            <p class="card-text card-text--main">A ninja from The Hidden Sound Village and member of The Sound Five.he
                                 was the physically strongest member of the Sound Four, but the weakest overall.
                                 According to the other members of the group, nevertheless, he was a formidable opponent.
                                 Furthermore, Shikamaru stated that Jirōbō's prowess was at jōnin-level. In the anime,
@@ -625,7 +625,7 @@
                                 alt="Hanare" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hanare (ハナレ, Hanare) is a kunoichi from the Jōmae Village. </p>
+                            <p class="card-text card-text--main">Hanare (ハナレ, Hanare) is a kunoichi from the Jōmae Village. </p>
                             <p class="card-text">As a young child, Hanare was said to be very lonely since she had never known her family
                                 or seen
                                 her own village. She was trained from an early age in the art of espionage. One day, she
@@ -658,7 +658,7 @@
                             <img src="./Images/fuka.jpg" alt="Fūka" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Fūka was portrayed as a seductive vixen as a way to lure her prey in
+                            <p class="card-text card-text--main">Fūka was portrayed as a seductive vixen as a way to lure her prey in
                                 and kill them with an Execution by Kiss.</p>
                             <p class="card-text">She would further speed up the process by giving her targets a choice between a French or
                                 traditional kiss. Her most preferable victims were those with a natural affinity for
@@ -680,7 +680,7 @@
                             <img src="Images/Mizuki.png" alt="Mizuki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The first-ever person whom Naruto faced in a battle in order to know
+                            <p class="card-text card-text--main">The first-ever person whom Naruto faced in a battle in order to know
                                 his power and also get to know about his own ninja way. He thrashed him in the battle
                                 against him while saving Iruka Umino his sensei in his elementary Training Academy</p>
                             <p class="card-text"> Mizuki duped Naruto Uzumaki into stealing Konoha's Scroll of Seals for him. Originally,
@@ -705,7 +705,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Naruto's first battle against non-Konoha ninja happened at the start of
+                            <p class="card-text card-text--main">Naruto's first battle against non-Konoha ninja happened at the start of
                                 the Land of Waves Escort Mission arc. Two allies of Zabuza waited outside of Konoha in
                                 order to ambush Tazuna, who was being escorted by Team 7.</p>
                             <p class="card-text">These were two former Hidden Mist shinobi, known as the Demon Brothers, who had defected
@@ -734,7 +734,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">Madara Uchiha was the legendary leader of the Uchiha clan. He founded
+                            <p class="card-text card-text--main">Madara Uchiha was the legendary leader of the Uchiha clan. He founded
                                 Konohagakure alongside his childhood friend and rival, Hashirama Senju, with the
                                 intention of beginning an era of peace.</p>
                             <p class="card-text"> When the two couldn't agree on how to achieve that peace, they fought for control of the
@@ -756,7 +756,7 @@
                             <img src="./Images/tayuya.jpg" alt="Tayuya Image" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">A kunoichi from The Hidden Sound Village and a member of The Sound
+                            <p class="card-text card-text--main">A kunoichi from The Hidden Sound Village and a member of The Sound
                                 Five.</p>
                             <p class="card-text">Tayuya is one of Orochimaru's Sound Four Ninja. She is foul mouthed and ill tempered yet
                                 very powerful. Her only weapon is a flute which she can use to summon three giant demons
@@ -776,7 +776,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">The main villain of Clash of Ninja Revolution 2, she's an ex-ANBU
+                            <p class="card-text card-text--main">The main villain of Clash of Ninja Revolution 2, she's an ex-ANBU
                                 member.</p>
 
                         </div>
@@ -793,7 +793,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">Tenten is one of the main supporting characters in the Naruto
+                            <p class="card-text card-text--main">Tenten is one of the main supporting characters in the Naruto
                                 anime/manga series and the Boruto: Naruto Next Generations anime/manga series. Shis a
                                 chūnin-level kunoichi of Konohagakure and member of Team Guy</p>
 
@@ -809,7 +809,7 @@
                             <img src="images/Itachi.png" alt="Itachi Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Itachi Uchiha is a fictional character in the Naruto manga and anime
+                            <p class="card-text card-text--main">Itachi Uchiha is a fictional character in the Naruto manga and anime
                                 series created by Masashi Kishimoto.</p>
                             <p class="card-text">Itachi is the older brother of Sasuke Uchiha, and is responsible for killing all the
                                 members of their clan, sparing only Sasuke. He appears working as a terrorist from the
@@ -830,7 +830,7 @@
                             <img src="Images/Isaribi.jpg" alt="Isaribi" height="280px" width="400px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text"> Isaribi was a part sea creature whose charecter arc was similar to
+                            <p class="card-text card-text--main"> Isaribi was a part sea creature whose charecter arc was similar to
                                 that of Naruto. She received a lot of hate for not being/behaving like the other members
                                 of her clan. Naruto shows her the power of friendship and fills her with hope. Amachi-
                                 the scientist to made Isaribi into the sea creature clearly exrpesses he had no
@@ -852,7 +852,7 @@
                                 alt="Kurama" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Kurama is the Nine-Tailed Fox demon that resides within Naruto and
+                            <p class="card-text card-text--main">Kurama is the Nine-Tailed Fox demon that resides within Naruto and
                                 augments his power. He is the most powerful tailed beast. His power is equivalent to
                                 all the eight tailed beasts. He was in contract with Madara Uchicha during the era of
                                 first
@@ -878,7 +878,7 @@
                             <img src="images/Hiashi_Hyuga.png" alt="Hiashi Hyuga" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hiashi Hyuga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
+                            <p class="card-text card-text--main">Hiashi Hyuga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
                                 well as the current head of the Hyūga clan.</p>
                             <p class="card-text">Hiashi was born only seconds before his twin brother Hizashi, making Hiashi the head of
                                 the Hyūga clan and Hizashi a member of the branch house, whose only purpose in life
@@ -901,7 +901,7 @@
                             <img src="./Images/bansai.png" alt="Bansai" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Bansai is an elder ninja monk in the Fire Temple as well as the Head
+                            <p class="card-text card-text--main">Bansai is an elder ninja monk in the Fire Temple as well as the Head
                                 Monk of the temple.</p>
                             <p class="card-text">Bansai is a very kind person who cares about his comrades deeply as seen when he said a
                                 prayer for Asuma Sarutobi before he set out for battle.</p>
@@ -919,7 +919,7 @@
                             <img src="Images/minatoNew.jpg" alt="Minato" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Minato Namikaze is a character in the Naruto universe. He is better
+                            <p class="card-text card-text--main">Minato Namikaze is a character in the Naruto universe. He is better
                                 known as The Fourth Hokage or as Konoha's Yellow Flash for his ability to use the Flying
                                 Thunder God Technique. He is also the father of series protagonist, Naruto. He is the
                                 teacher of Kakashi Hatake, Obito Uchiha and Rin Nohara. He is also one of Jiraiya's
@@ -938,7 +938,7 @@
                             <img src="./Images/kawaki2.jpg" alt="kawaki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Kawaki (カワキ, Kawaki) is a tattooed youth who became a member of Kara
+                            <p class="card-text card-text--main">Kawaki (カワキ, Kawaki) is a tattooed youth who became a member of Kara
                                 after being brought by Jigen from a drunkard father, bearing a tattoo of the Roman
                                 numeral IX under his left eye and bestowed a Kama mark by Jigen to be made into a living
                                 weapon for Kara. He was heavily modified with microscopic Shinobi-Ware implanted in his
@@ -963,7 +963,7 @@
                             <img src="./Images/eida.png" alt="Eida" height="350px" width="350px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">In his plot to kill Jigen, Amado heavily modified Eida, along with her
+                            <p class="card-text card-text--main">In his plot to kill Jigen, Amado heavily modified Eida, along with her
                                 younger brother Daemon with Shinobi-Ware with capabilities exceeding that of Jigen.
                                 The effects of her modifications left her forever despising Amado.
                                 Because of her superior might, Jigen had ordered for her disposal.
@@ -989,7 +989,7 @@
                             <img src="./Images/Daemon.webp" alt="Daemon" height="350px" width="350px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Daemon used to be a member of Kara.
+                            <p class="card-text card-text--main">Daemon used to be a member of Kara.
                                 He was one of the cyborgs that Isshiki ordered to be dismantled.
                                 However, Boro was allured by Ada, and he couldn't bring himself to finish the task, and
                                 he was manipulated to safely store Ada and Daemon in pods for several years.
@@ -1008,7 +1008,7 @@
                             <img src="./Images/nagato.png" alt="Nagato Uzumaki" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Nagato was known primarily under the alias of Pain. Nagato is the
+                            <p class="card-text card-text--main">Nagato was known primarily under the alias of Pain. Nagato is the
                                 figurehead leader of the Akatsuki who wishes to capture the tailed beasts sealed into
                                 various people around the shinobi world. After acquiring and sealing most
                                 of the beasts within a statue, Nagato's superior sends him to capture the Nine-Tailed
@@ -1031,7 +1031,7 @@
                             <img src="./Images/yamato.png" alt="Nagato Uzumaki" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Seeing how pivotal of a role Kakashi played as the leader of Team Seven
+                            <p class="card-text card-text--main">Seeing how pivotal of a role Kakashi played as the leader of Team Seven
                                 with Naruto, Sakura, and Sasuke, there were high expectations for Yamato when he
                                 temporarily filled Kakashi's leadership position with the new Team Seven.
 
@@ -1057,7 +1057,7 @@
                                 alt="Hashirama Senju image" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The First hokage, leader of the Senju clan, one of the founders of
+                            <p class="card-text card-text--main">The First hokage, leader of the Senju clan, one of the founders of
                                 Konohagakure. Older brother to the Second Hokage and Grandfather to the Fifth Hokage. He
                                 possesses the Wood Style and has a friend and rival called Madara Uchiha. He was the
                                 incarnation of Asura.
@@ -1081,7 +1081,7 @@
                             <img src="./Images/Yahiko.png" alt="anko" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Yahiko (弥彦, Yahiko) was a shinobi from Amegakure. Alongside his fellow
+                            <p class="card-text card-text--main">Yahiko (弥彦, Yahiko) was a shinobi from Amegakure. Alongside his fellow
                                 war orphans, Nagato and Konan, he founded and led the Akatsuki in an attempt to bring
                                 peace. Following Yahiko's death, Nagato would turn his body into the
                                 Deva Path of his Six Paths of Pain, which he used as the continued public image of
@@ -1101,7 +1101,7 @@
                             <img src="./Images/deidara69.jpg" alt="Deidara" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Deidara is a member of the Akatsuki group, Deidara was partnered with
+                            <p class="card-text card-text--main">Deidara is a member of the Akatsuki group, Deidara was partnered with
                                 Sasori before his death, after which he partnered Tobi.</p>
                             <p class="card-text">Deidara has a very unique ability, he uses his hands where his palms posses mouths that
                                 when feed a certain clay explosive can create a flying bird or many small spiders that
@@ -1122,7 +1122,7 @@
                             <img src="./Images/Tsunadexx.png" alt="anko" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Tsunade (綱手, Tsunade) is a descendant of the Senju and Uzumaki Clan,
+                            <p class="card-text card-text--main">Tsunade (綱手, Tsunade) is a descendant of the Senju and Uzumaki Clan,
                                 and is one of Konohagakure's Sannin. She is famed as the world's strongest kunoichi and
                                 its greatest medical-nin. The repeated loss of her loved ones caused Tsunade to later
                                 abandon the life of a shinobi for many years. She is eventually persuaded to return to
@@ -1142,7 +1142,7 @@
                             <img src="./Images/kimimaro.png" alt="kimimaro" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 Kimimaro was the sole survivor of the Kaguya clan. Upon dedicating his life to
                                 Orochimaru, he became the leader of the formerly-named Sound Five (音隠れの忍五人衆, Otogakure
                                 no Shinobi Gonin Shū, literally meaning: Hidden Sound Shinobi Five People), until he
@@ -1162,7 +1162,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">Zabuza Momochi, a mercenary assassin and former member of the Seven
+                            <p class="card-text card-text--main">Zabuza Momochi, a mercenary assassin and former member of the Seven
                                 Swordsmen of the Mist. He is a master of silent assassinations
                                 and together with his water Jutsu he is feared as The Demon of the Hidden Mist. He was
                                 defeated by Kakashi and he gave his live to compensate the feelingof sorrow he felt
@@ -1182,7 +1182,7 @@
                             <img src="./Images/Casual_Haku.png" alt="Haku" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Haku was an orphan from the Land of Water, and a descendant of the Yuki
+                            <p class="card-text card-text--main">Haku was an orphan from the Land of Water, and a descendant of the Yuki
                                 clan. He later became a shinobi under Zabuza Momochi's tutelage whom he later partnered
                                 with, ultimately becoming a Mercenary Ninja</p>
                             <p class="card-text">Haku was a 15-year-old boy with an androgynous appearance and was even viewed as being
@@ -1204,7 +1204,7 @@
                             <img src="./Images/Tonton.png" alt="Tonton" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Tonton is Tsunade's ninja pig, often kept in the care of Shizune.</p>
+                            <p class="card-text card-text--main">Tonton is Tsunade's ninja pig, often kept in the care of Shizune.</p>
                             <p class="card-text">Above all else, Tonton is a highly devoted, and dutiful pet pig. Her devotion to Tsunade
                                 was noted during her master's battle with the other Sannin, which she watched in earnest
                                 as Gamakichi and Gamatatsu bickered. This even surfaced during the Fourth Shinobi World
@@ -1227,7 +1227,7 @@
                             <img src="./Images/sand siblings.jpeg" alt="Sand-Siblings" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 The Three Sand Siblings is the collective name for the children of Sunagakure's Fourth
                                 Kazekage: Temari, Kankurō and Gaara. Having undergone the gruelling training of their
                                 village, these three are regarded as elite shinobi of their village that excel
@@ -1253,7 +1253,7 @@
                             <img src="./Images/Hidan.png" alt="Hidan" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hidan is an S-rank missing-nin who defected from Yugakure and later
+                            <p class="card-text card-text--main">Hidan is an S-rank missing-nin who defected from Yugakure and later
                                 joined the Akatsuki. There, he was partnered with Kakuzu,
                                 despite the two's somewhat mutual dislike of each other.</p>
                             <p class="card-text">Hidan doesn't always seem like the most intelligent of the Akatsuki. He certainly doesn't
@@ -1276,7 +1276,7 @@
                             <img src="./Images/sakon_ukon.jpg" alt="sakon and ukon" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 They work for Orochi-Maru, an evil genius dead set on discovering and mastering every
                                 jutsu in the world. Sakon and Ukon are one his main pawns, as a member of the sound 5
                                 (Dark sound ninja with horrifying skills and abilities.)
@@ -1305,7 +1305,7 @@
                                 alt=Zabuza height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Zabuza Momochi (桃地再不斬, Momochi Zabuza), given the moniker Demon of the
+                            <p class="card-text card-text--main">Zabuza Momochi (桃地再不斬, Momochi Zabuza), given the moniker Demon of the
                                 Hidden Mist (霧隠れの鬼人, Kirigakure no Kijin), was a missing-nin from Kirigakure's Seven
                                 Ninja Swordsmen of the Mist.</p>
                             <p class="card-text">As a Hidden Mist ninja, Zabuza's forte is using water-nature chakra to manipulate water
@@ -1326,7 +1326,7 @@
                             <img src="./Images/Tenten.jpg" alt="Tenten" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">In the Konoha 11, which consists of many of Naruto's peers in Team
+                            <p class="card-text card-text--main">In the Konoha 11, which consists of many of Naruto's peers in Team
                                 Seven, Team Eight, Team Ten, and Team Guy, there are ninjas like Rock Lee who excel in
                                 taijutsu as well as ninjas who are considered geniuses like Shikamaru
                                 and Neji. There is one ninja among the eleven, however, who definitely falls short of
@@ -1350,7 +1350,7 @@
                             <img src="./Images/GuyGawd.png" alt="Might Guy" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Might Guy (マイト・ガイ, Maito Gai) is a jōnin of Konohagakure. A master of
+                            <p class="card-text card-text--main">Might Guy (マイト・ガイ, Maito Gai) is a jōnin of Konohagakure. A master of
                                 taijutsu, Guy leads and passes his wisdom onto the members of Team Guy.</p>
                             <p class="card-text">Guy is the son of Might Duy, who was known throughout Konoha as the "Eternal Genin". Duy
                                 was not bothered by this moniker and instead was grateful that other people cared enough
@@ -1372,7 +1372,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
+                            <p class="card-text card-text--main">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
                                 who always enjoys a good smoke. He goes out with Kurenai, a strong Genjutsu user.
                                 Revealed to be the son of Hiruzen Sarutobi, the third Hokage and is uncle
                                 to Konohamaru Sarutobi. Jonin squad leader of Team 10, the current Ino-Shika-Chou Trio
@@ -1398,7 +1398,7 @@
                             <img src="./Images/Hidan.jpg" alt="Hidan" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hidan (飛段) is the immortal, foul-mouthed, and sadomasochistic partner
+                            <p class="card-text card-text--main">Hidan (飛段) is the immortal, foul-mouthed, and sadomasochistic partner
                                 of Kakuzu and a former ninja of Yugakure, the Village Hidden in Boiling Water. He is a
                                 member of the Way of Jashin (ジャシン, lit. "evil god") religion which
                                 worships a deity of the same name and believes that anything less than death and utter
@@ -1425,7 +1425,7 @@
                             <img src="./Images/kakashi.jpg" alt="Naruto Uzumaki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
+                            <p class="card-text card-text--main">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
                                 village. He is the teacher (sensei) of Uzumaki Naruto, Haruno Sakura and Uchiha Sasuke.
                                 His teacher was the fourth hokage, Minato Namikaze and his teammates
                                 were Obito Uchiha and Rin Nohara. His rival is Might Guy.</p>
@@ -1448,7 +1448,7 @@
                             <img src="./Images/fugaku.jpeg" alt="Fugaku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Fugaku Uchiha (うちはフガク, Uchiha Fugaku) was a shinobi of Konohagakure. He
+                            <p class="card-text card-text--main">Fugaku Uchiha (うちはフガク, Uchiha Fugaku) was a shinobi of Konohagakure. He
                                 was the head of the Uchiha clan as well as the leader of the Konoha Military Police
                                 Force.
                             </p>
@@ -1473,7 +1473,7 @@
                             <img src="./Images/inari.png" alt="Fugaku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
+                            <p class="card-text card-text--main">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
                             <p class="card-text">Inari is the son of Tsunami, and is also Tazuna's grandson. His biological father died
                                 before he got to know him.
                             </p>Inari first appeared to be a very tough individual, though this was just a ruse he put
@@ -1494,7 +1494,7 @@
                             <img src="Images/Raikage3.png" alt="Fugaku" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
+                            <p class="card-text card-text--main">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
                                 Lightning Shadow) of Kumogakure, was renowned to be the greatest Raikage the village has
                                 ever had.</p>
                             <p class="card-text">The Third Raikage's rule was punctuated by the berserk attacks of the Eight-Tails but as
@@ -1523,7 +1523,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Mikoto Uchiha (うちはミコト, Uchiha Mikoto) was a jōnin from Konohagakure's
+                            <p class="card-text card-text--main">Mikoto Uchiha (うちはミコト, Uchiha Mikoto) was a jōnin from Konohagakure's
                                 Uchiha clan.
                             </p>
                             <p class="card-text">Mikoto was a very gentle and kind woman, but could also be stern and strict when she
@@ -1549,7 +1549,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Black Zetsu (黒ゼツ, Kuro Zetsu) was the physical manifestation of
+                            <p class="card-text card-text--main">Black Zetsu (黒ゼツ, Kuro Zetsu) was the physical manifestation of
                                 Princess Kaguya Ōtsutsuki's will. It secretly instigated many of the events that shaped
                                 the shinobi world to secure Kaguya's revival. To further its plans, it
                                 posed as Madara Uchiha's manifested will and then partnered with White Zetsu to become
@@ -1581,7 +1581,7 @@
                             <img src="./Images/MitoUzumaki.jpg" alt="Mito" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Mito Uzumaki (うずまきミト, Uzumaki Mito) was a kunoichi who originated from
+                            <p class="card-text card-text--main">Mito Uzumaki (うずまきミト, Uzumaki Mito) was a kunoichi who originated from
                                 Uzushiogakure's Uzumaki clan. After migrating to Konohagakure, she married Hashirama
                                 Senju, the village's First Hokage, and later became the first jinchūriki
                                 of the Nine-Tails following the events at the Valley of the End.
@@ -1608,7 +1608,7 @@
                             <img src="./Images/Guren.png" alt="Guren" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Guren (紅蓮, Guren) is a kunoichi from Otogakure and the leader of a
+                            <p class="card-text card-text--main">Guren (紅蓮, Guren) is a kunoichi from Otogakure and the leader of a
                                 group of Orochimaru's subordinates,
                                 possessing the unique Crystal Release kekkei genkai.
                             </p>
@@ -1634,7 +1634,7 @@
                             <img src="./Images/Hanzo-the-Salamander.jpg" alt="HANZO" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hanzō (半蔵, Hanzō), feared as Hanzō of the Salamander (山椒魚の半蔵, Sanshōuo
+                            <p class="card-text card-text--main">Hanzō (半蔵, Hanzō), feared as Hanzō of the Salamander (山椒魚の半蔵, Sanshōuo
                                 no Hanzō),
                                 was a legendary shinobi, and the leader of Amegakure during his lifetime.
                             </p>
@@ -1662,7 +1662,7 @@
                                 alt="Konan" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Konan (小南, Konan) was a kunoichi from Amegakure and a founding member
+                            <p class="card-text card-text--main">Konan (小南, Konan) was a kunoichi from Amegakure and a founding member
                                 of the original Akatsuki. After Yahiko's death, she was partnered with Nagato, who had
                                 since taken control of Akatsuki, and was the only member to call him
                                 by his name. After Nagato's death, Konan defected from Akatsuki and became the de facto
@@ -1694,7 +1694,7 @@
                         </div>
                         <div class="flip-card-back">
 
-                            <p class="card-text">A ninja from The Hidden Sound Village and member of The Sound Five.</p>
+                            <p class="card-text card-text--main">A ninja from The Hidden Sound Village and member of The Sound Five.</p>
                             <p class="card-text">Kidomaru was killed fighting against Neji Hyuga</p>
                         </div>
                     </div>
@@ -1710,7 +1710,7 @@
 				<img src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt=Karin height="300px" width="300px" class="img_card">
 			    </div>
 			    <div class="flip-card-back">
-				<p class="card-text">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
+				<p class="card-text card-text--main">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
 				<p class="card-text">Karin has been praised for her abilities by both Obito Uchiha and Orochimaru, the latter deciding to take her with him for that reason. Despite being mostly a non-combatant, Orochimaru referred to Karin as one of his good experiments,[4] and had enough faith in her skills to put her in charge of the Southern Hideout's prison, since she made escaping impossible. Karin later demonstrated these skills most predominantly during the Fourth Shinobi World War, where she destroyed much of Tobi's giant wooden statue.</p>
 			    </div>
 			</div>
@@ -1728,7 +1728,7 @@
                             <img src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
+                            <p class="card-text card-text--main">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
                                 specialises in training elite ninja. He also served as the leader of Team Ebisu, which
                                 consisted of Konohamaru Sarutobi, Udon, and Moegi.</p>
                             <p class="card-text">Ebisu is portrayed as a stern and "by-the-book" type of person. Initially, he expressed
@@ -1756,7 +1756,7 @@
                             <img src="./Images/tobirama senju.png" alt="Ebisu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Tobirama Senju (千手扉間, Senju Tobirama) was a member of the renowned
+                            <p class="card-text card-text--main">Tobirama Senju (千手扉間, Senju Tobirama) was a member of the renowned
                                 Senju clan, who together with his elder brother and the Uchiha clan, founded the first
                                 shinobi village: Konohagakure. Throughout his lifetime, Tobirama would
                                 work tirelessly to achieve political stability and implement the institutions that made
@@ -1783,7 +1783,7 @@
                             <img src="./Images/hinata.jpeg" alt="Hinata" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hinata, the eldest of Hiashi Hyuga's two children, is raised as the
+                            <p class="card-text card-text--main">Hinata, the eldest of Hiashi Hyuga's two children, is raised as the
                                 heiress to Hyuga clan's main household due to Hiashi being the elder between him and his
                                 twin brother, Hizashi, and thereby making Hiashi head of the clan
                                 while Hizashi is demoted to the Branch House whose only purpose is to serve the upper
@@ -1806,7 +1806,7 @@
                             <img src="./Images/hiashi.jpeg" alt="Hiashi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
+                            <p class="card-text card-text--main">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
                                 well as the current head of the Hyūga clan.</p>
                             <p class="card-text">Hiashi was born just seconds before his twin brother Hizashi, which makes Hiashi the mind
                                 of this Hyūga clan. Since the leader of the Hyūga clan, Hiashi is undoubtedly a strong
@@ -1831,7 +1831,7 @@
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
+                            <p class="card-text card-text--main">A Jounin from The Hidden Leaf Village. A very calm and strong ninja,
                                 who always enjoys a good smoke. He goes out with Kurenai, a strong Genjutsu user.
                                 Revealed to be the son of Hiruzen Sarutobi, the third Hokage and is uncle
                                 to Konohamaru Sarutobi. Jonin squad leader of Team 10, the current Ino-Shika-Chou Trio
@@ -1860,7 +1860,7 @@
                             <img src="./Images/choza_akimichi.png" alt="Choza Akimichi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Choza Akimichi (秋道チョウザ, Akimichi Chōza) is a jōnin of Konohagakure and
+                            <p class="card-text card-text--main">Choza Akimichi (秋道チョウザ, Akimichi Chōza) is a jōnin of Konohagakure and
                                 former teammate of Shikaku Nara and Inoichi Yamanaka. Together they were the previous
                                 Ino–Shika–Chō trio. He is also the fifteenth head of the Akimichi clan (秋道15代目当主,
                                 Akimichi Jūgodaime Tōshu).</p>
@@ -1877,7 +1877,7 @@
                             <img src="./Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the
+                            <p class="card-text card-text--main">Madara Uchiha (うちはマダラ, Uchiha Madara) was the legendary leader of the
                                 Uchiha clan. He founded Konohagakure alongside his childhood friend and rival, Hashirama
                                 Senju, with the intention of beginning an era of peace. When thetwo couldn't agree on
                                 how to achieve that peace, they fought for control of the village, a conflict which
@@ -1898,7 +1898,7 @@
                             <img src="./Images/Izuna_Uchiha.png" alt="Madara Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Izuna Uchiha (うちはイズナ, Uchiha Izuna) was a shinobi of the Uchiha clan.
+                            <p class="card-text card-text--main">Izuna Uchiha (うちはイズナ, Uchiha Izuna) was a shinobi of the Uchiha clan.
                                 He, along with his brother Madara, were renowned as the clan's two strongest members in
                                 their lifetime. </p>
                         </div>
@@ -1912,7 +1912,7 @@
                             <img src="./Images/hashirama.jpg" alt="Hashirama Senju" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The First hokage, leader of the Senju clan, one of the founders of
+                            <p class="card-text card-text--main">The First hokage, leader of the Senju clan, one of the founders of
                                 Konohagakure. Older brother to the Second Hokage and Grandfather to the Fifth Hokage. He
                                 possesses the Wood Style and has a friend and rival called Madara Uchiha.</p>
                             <p class="card-text">He also showed great tactical skill and deceptive abilities, waiting until Madara became
@@ -1931,7 +1931,7 @@
                             <img src="./Images/Kaguya_Ōtsutsuki.png" alt=" " height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Kaguya was the originator of shinobi in the world in which Naruto takes
+                            <p class="card-text card-text--main">Kaguya was the originator of shinobi in the world in which Naruto takes
                                 place. She was once benevolent and respected, but became corrupted. She is the final
                                 villain to oppose Naruto's team in the manga.</p>
                             <p class="card-text">The final boss of Naruto turned out to be a woman! Who could've seen that coming?! One
@@ -1955,7 +1955,7 @@
                             <img src="./Images/KillerBee.png" alt="Killer Bee" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Killer B is a major supporting character in the anime and manga Naruto
+                            <p class="card-text card-text--main">Killer B is a major supporting character in the anime and manga Naruto
                                 Shippuden. He is the host of Gyuki, The Eight-tailed demon Ox. He was a shinobi who
                                 trained Naruto and is partners with him while fighting Obito Uchiha.</p>
                             <p class="card-text">Killer B (キラービー, Kirā Bī, Viz: Killer Bee) is a shinobi from Kumogakure. He is the most
@@ -1977,7 +1977,7 @@
                             <img src="./Images/Gamabunta.png" alt="Gamabunta" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Gamabunta is a grumpy, stubborn and highly apathetic toad. He was
+                            <p class="card-text card-text--main">Gamabunta is a grumpy, stubborn and highly apathetic toad. He was
                                 summoned by lord fourth Hokage , sensei Jiraiya and by Naruto.</p>
                             <p class="card-text">Gamabunta can spew oil from his mouth and use it to enhance fire. He is one of the
                                 biggest summon animal in the series. He was firest summoned by naruto when he was
@@ -1998,7 +1998,7 @@
                                 alt="Juubi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The ten-tailed beast was created by Kaguya Otsutsuki and later had its
+                            <p class="card-text card-text--main">The ten-tailed beast was created by Kaguya Otsutsuki and later had its
                                 chakra split into the nine tailed beasts.</p>
                             <p class="card-text">The Ten-Tailed Beast (十尾, Jūbi) is the original, primordial demon of the Naruto universe.
                                 All nine of the tailed beasts are but portions of chakra divided from the Ten-Tails.
@@ -2019,7 +2019,7 @@
                             <img src="./Images/matatabi.png" alt="Matatabi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Matatabi also known as Two-Tails, is one of the nine tailed
+                            <p class="card-text card-text--main">Matatabi also known as Two-Tails, is one of the nine tailed
                                 beast.Yugito Nii is the jinchūriki of her</p>
                             <p class="card-text">Matatabi has shown to be respectful and polite towards others,she is completely engulfed
                                 in blue flames.Matatabi also has flexible muscles, which grant it great speed despite
@@ -2048,7 +2048,7 @@
 
                             <h2 class="card-title">Obito Uchiha</h2>
 
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
 
                                 A character from the anime series Naruto. He claimed to be Madara Uchiha the man who
                                 fought the First Hokage, Hashirama. He is the main antagonist of the Naruto Series. He
@@ -2086,7 +2086,7 @@
 
                             <h2 class="card-title">Rin Nohara</h2>
 
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
 
                                 Rin Nohara was a chūnin of Konohagakure and a member of Team Minato alongside Kakashi
                                 Hatake and Obito Uchiha. Rin was forcibly made a vessel for the Three-Tails (Isobu) as a
@@ -2110,7 +2110,7 @@
                         </div>
                         <div class="flip-card-back">
                             <h2 class="card-title">Jiraiya</h2>
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
                                 Jiraiya is one of the "Three Legendary Sannin" that is known through out the ninja
                                 world. Jiraiya is the teacher of many characters in the Naruto universe including
                                 Naruto and the 4th Hokage. He is a renowned pervert and author of many adult books.
@@ -2140,7 +2140,7 @@
                             <div class="card-body">
                                 <h2 class="card-title">Iruka Umino</h2>
 
-                                <p class="card-text">The main teacher in the ninja acedemy he grow up like Naruto as
+                                <p class="card-text card-text--main">The main teacher in the ninja acedemy he grow up like Naruto as
                                     an orphan and thus acts like a father to Naruto. The man that voices Iruka umino
                                     is Quinton Flynn.</p>
                             </div>
@@ -2161,7 +2161,7 @@
                         <div class="flip-card-back">
                             <div class="card-body">
                                 <h2 class="card-title">Orochimaru</h2>
-                                <p class="card-text">With a life-ambition to learn all of the world's secrets,
+                                <p class="card-text card-text--main">With a life-ambition to learn all of the world's secrets,
                                     Orochimaru seeks immortality so that he might live all of the lives necessary to
                                     accomplish his task. After being caught red-handed performing unethical
                                     experiments on his fellow citizens for the sake of this immortality</p>
@@ -2186,7 +2186,7 @@
                         <div class="flip-card-back">
                             <div class="card-body">
                                 <h2 class="card-title">Kakuzu</h2>
-                                <p class="card-text">Kakuzu is a member of the criminal organization known as
+                                <p class="card-text card-text--main">Kakuzu is a member of the criminal organization known as
                                     Akatsuki. He is the accountant for the Akatsuki which makes him obsessed
                                     with money, he also possesses five hearts. He once fought the first hokage
                                     Hashirama and lost. He is a former shinobi from the village hidden in the
@@ -2210,7 +2210,7 @@
                             <div class="card-body">
                                 <h2 class="card-title">Kurama</h2>
 
-                                <p class="card-text">Kurama (九喇嘛, Kurama), more commonly known as the
+                                <p class="card-text card-text--main">Kurama (九喇嘛, Kurama), more commonly known as the
                                     Nine-Tails (九尾, Kyūbi),
                                     was one of the nine tailed beasts.
                                     After being sealed into Naruto Uzumaki, Kurama attempts to maintain its
@@ -2235,7 +2235,7 @@
                         </div>
                         <div class="flip-card-back">
                             <h2 class="card-title">Teuchi</h2>
-                            <p class="card-text">As a teenager 34 years before the Fourth Shinobi World
+                            <p class="card-text card-text--main">As a teenager 34 years before the Fourth Shinobi World
                                 War, Teuchi devoted his life to making
                                 ramen. More than a decade later, he had a daughter called Ayame.</p>
                             <p class="card-text">Teuchi is a very kind and jovial man. Often seen smiling, he and Ayame
@@ -2258,7 +2258,7 @@
                         </div>
                         <div class="flip-card-back">
                             <h2 class="card-title">Pain </h2>
-                            <p class="card-text">
+                            <p class="card-text card-text--main">
 
                                 Pain is the recognised leader of Akatsuki and leader of Amegakure. He
                                 wields the legendary Rinnegan and refers to himself as a god. His real
@@ -2282,7 +2282,7 @@
                         <div class="flip-card-back">
                             <div class="card-body">
                                 <h2 class="card-title">Ebizo</h2>
-                                <p class="card-text">
+                                <p class="card-text card-text--main">
                                     Ebizō (エビゾウ, Ebizō), called Honoured Grandfather Ebizō (エビゾウジイ様,
                                     Ebizō-jiisama) by the Suna villagers, is highly revered in
                                     Sunagakure. He and his older sister, Chiyo, are known as the
@@ -2306,7 +2306,7 @@
                             <div class="card-body">
                                 <h2 class="card-title">Nekobaa</h2>
 
-                                <p class="card-text">Nekobaa (猫バア, Nekobaa, English TV: Granny Cat,
+                                <p class="card-text card-text--main">Nekobaa (猫バア, Nekobaa, English TV: Granny Cat,
                                     literally meaning: Grandma Cat) is an old woman who lives in an
                                     abandoned city together with her granddaughter, Tamaki. She runs
                                     a supplies shop that the Uchiha clan used to use. She lives with
@@ -2328,7 +2328,7 @@
                             <div class="card-body">
                                 <h2 class="card-title">Jūzō Biwa</h2>
 
-                                <p class="card-text">Jūzō Biwa (枇杷十蔵, Biwa Jūzō) was a jōnin
+                                <p class="card-text card-text--main">Jūzō Biwa (枇杷十蔵, Biwa Jūzō) was a jōnin
                                     from Kirigakure and a member of the Seven Ninja Swordsmen of
                                     the Mist. In the anime, Jūzō deserted his village and became
                                     a member of Akatsuki, where he was partnered with Itachi
@@ -2370,7 +2370,7 @@
                                 alt='Rasa' height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">Rasa (羅砂, Rasa) was the Fourth Kazekage (四代目風影, Yondaime Kazekage, literally meaning: Fourth Wind Shadow) of Sunagakure. Renowned for his ability to use Gold Dust, Rasa's reign as Kazekage was marked by his frequent quelling of rampages by the One-Tailed Shukaku, which he had sealed into his youngest son, Gaara.Rasa was a very powerful shinobi, as evidenced by his title of Kazekage. He could even subdue a fully released tailed beast like Shukaku. The prospect of his retaliation was enough to keep a great group of Iwa-nin from sparking a conflict at the Land of Wind's border.He was shown to be quite observant, pinpointing Gaara's Third Eye that was spying on him and the other reincarnated Kage after Mū sensed his chakra. </p>
+                            <p class="card-text card-text--main">Rasa (羅砂, Rasa) was the Fourth Kazekage (四代目風影, Yondaime Kazekage, literally meaning: Fourth Wind Shadow) of Sunagakure. Renowned for his ability to use Gold Dust, Rasa's reign as Kazekage was marked by his frequent quelling of rampages by the One-Tailed Shukaku, which he had sealed into his youngest son, Gaara.Rasa was a very powerful shinobi, as evidenced by his title of Kazekage. He could even subdue a fully released tailed beast like Shukaku. The prospect of his retaliation was enough to keep a great group of Iwa-nin from sparking a conflict at the Land of Wind's border.He was shown to be quite observant, pinpointing Gaara's Third Eye that was spying on him and the other reincarnated Kage after Mū sensed his chakra. </p>
                         </div>
                     </div>
                 </div>
@@ -2385,7 +2385,7 @@
                         <img src="Images/gold_silver_bros.png" alt="Gold and Silver Brothers" height="300px" width="300px" class="img_card">
                     </div>
                     <div class="flip-card-back">
-                        <p class="card-text">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
+                        <p class="card-text card-text--main">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
                         <p class="card-text">They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
    </div>
                     </div>
@@ -2402,7 +2402,7 @@
                                 width="300px" class="img_card">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The Gold and Silver Brothers (金銀兄弟, Kingin
+                            <p class="card-text card-text--main">The Gold and Silver Brothers (金銀兄弟, Kingin
                                 Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no
                                 Hikari), were two infamous shinobi from Kumogakure, that
                                 were distantly related to the Sage of Six Paths.</p>
@@ -2430,7 +2430,7 @@
                                 class="img_card">
                         </div>
                         <div class="flip-card-back">
-                            <p class="card-text">The Asura Path (修羅道) grants the user the
+                            <p class="card-text card-text--main">The Asura Path (修羅道) grants the user the
                                 ability to augment their own body to summon mechanised
                                 armour and various ballistic and mechanical weaponry.</p>
                             <p class="card-text">Through the Asura Path, the user is able to form up to four
@@ -2450,7 +2450,7 @@
                         <img src=https://static.wikia.nocookie.net/naruto/images/7/70/A.png/revision/latest/scale-to-width-down/1000?cb=20141016130545 alt="A (First Raikage)" height="300px" width="300px" class="img_card">
                     </div>
                     <div class="flip-card-back">
-                        <p class="card-text">A (エー, Ē, Viz: Ei, English TV: Ay) was the First Raikage (初代雷影, Shodai Raikage, literally meaning:
+                        <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the First Raikage (初代雷影, Shodai Raikage, literally meaning:
                              First or Founding Lightning Shadow) who founded Kumogakure in the Land of Lightning.During his leadership in the early days of Kumogakure after the Warring States Period,
                               A presumably sent the Gold and Silver Brothers to capture the Nine-Tails, a task at which they ultimately failed.
                         <p class="card-text">While not much was seen of his personality, A did seemingly have a verbal tic, ending his sentences with "yo" (よ).
@@ -2468,7 +2468,7 @@
                         <img src=https://static.wikia.nocookie.net/naruto/images/3/3f/2nd_Raikage.png/revision/latest/scale-to-width-down/1000?cb=20211214203620 alt="A (Second Raikage)" height="300px" width="300px" class="img_card">
                     </div>
                     <div class="flip-card-back">
-                        <p class="card-text">A (エー, Ē, Viz: Ei, English TV: Ay) was the Second Raikage (二代目雷影, Nidaime Raikage, literally meaning: Second Lightning Shadow) of Kumogakure.
+                        <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Second Raikage (二代目雷影, Nidaime Raikage, literally meaning: Second Lightning Shadow) of Kumogakure.
                             Throughout his reign he worked hard towards building peace between the other hidden villages.Before becoming the Second Raikage, he had a long tenure as the First Raikage's guard. During his service, he accompanied him to the first ever Five Kage Summit. 
                             There he stood behind the First watching diligently as the proceedings unfolded.
                             Eventually, his long service and dedication earned him the appointment of Second Raikage.
@@ -2487,7 +2487,7 @@
                         <img src=https://static.wikia.nocookie.net/naruto/images/f/f5/Raikage3.png/revision/latest/scale-to-width-down/1000?cb=20160116123903 alt="A (Third Raikage)" height="300px" width="300px" class="img_card">
                     </div>
                     <div class="flip-card-back">
-                        <p class="card-text">A (エー, Ē, Viz: Ei, English TV: Ay) was the Third Raikage (三代目雷影, Sandaime Raikage, literally meaning:
+                        <p class="card-text card-text--main">A (エー, Ē, Viz: Ei, English TV: Ay) was the Third Raikage (三代目雷影, Sandaime Raikage, literally meaning:
                              Third Lightning Shadow) of Kumogakure, renowned to be the greatest Raikage the village has ever had.
                              A's rule was punctuated by the berserk attacks of the Eight-Tails but as Kumogakure couldn't afford to dispose of such a valuable war deterrent, he was forced to look for a suitable jinchūriki in quick succession, after the conclusion of each rampage.
                              During one of these attacks, A fought the Eight-Tails alone, allowing his comrades to escape. Their battle resulted in A receiving a self-inflicted wound to the chest after he collapsed upon his own hand, which became his life's shame.

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                             <p class="card-text">Naruto Uzumaki is the main protagonist in the popular manga and anime
                                 series Naruto. He is a cheerful, hyperactive, strong-willed, and occasionally
                                 simple-minded young shinobi from the village of Konoha (or Leaf Village).</p>
-                            <p>Since Naruto has the Nine Tails Fox sealed inside him, he is able to use the Fox's
+                            <p class="card-text">Since Naruto has the Nine Tails Fox sealed inside him, he is able to use the Fox's
                                 chakra, which is much greater than the average human. Initially Naruto and the Fox hated
                                 each other, and would rarely grant Naruto his power
                                 unless they were going to die. Eventually, they become friends, and Naruto then refers
@@ -168,7 +168,7 @@
                                 sarcastic lines and made every effort he could to get under Karin's skin.
 
                             </p>
-                            <p>The above line was especially funny coming from Suigetsu, as the audience got the
+                            <p class="card-text">The above line was especially funny coming from Suigetsu, as the audience got the
                                 distinct impression that he probably wasn't a true believer in Sasuke's dream. It was
                                 even funnier in the moment, as he made a decisive gesture with a spoon he was using at
                                 the time.</p>
@@ -237,7 +237,7 @@
                                 Ninjas” of the Lord of the Fire Land. There he will meet Asuma Sarutobi, son of the
                                 third Hokage. Their mission was to escort and protect the Daimyo of the Land of
                                 Fire.</p>
-                            <p>Today he lives in the Temple of Fire with his disciples. He took under his wing a young
+                            <p class="card-text">Today he lives in the Temple of Fire with his disciples. He took under his wing a young
                                 man named Sora, the son of one of the 12 deceased guardian ninjas. His head having been
                                 put on a price of 30 million ryos, he was assassinated by Kakuzu and Hidan during a
                                 fight at the Fire temple. After this clash, the Fire Temple was destroyed. Hidan and
@@ -328,7 +328,7 @@
                                 father's teachings, and as a result, would have to clash bitterly against his elder
                                 brother Indra. Asura is also credited with being the progenitor of both the Senju and
                                 Uzumaki clans.</p>
-                            <p>With the power entrusted to him by his father, Asura gained access to the Six Paths
+                            <p class="card-text">With the power entrusted to him by his father, Asura gained access to the Six Paths
                                 Senjutsu, allowing him to augment himself and his various techniques. In this state, he
                                 could fly and manifest a giant three-faced, six-armed avatar, Six Paths: Kunitsukami.
                             </p>
@@ -347,7 +347,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Hana is a kunoichi from Konoha village. She is Kiba's sister and
                                 Tsume's daughter</p>
-                            <p>Hana also specializes in animal medicine: she is a veterinarian. His companions are 3 dog
+                            <p class="card-text">Hana also specializes in animal medicine: she is a veterinarian. His companions are 3 dog
                                 brothers: Les Trois Frères Haimaru.</p>
                         </div>
                     </div>
@@ -366,7 +366,7 @@
                                 while protecting her.From the grief brought on by his death, as well as feelings of
                                 guilt that he would not have died had Izumi been stronger,Izumi eventually awakened her
                                 Sharingan. She and her mother afterwards rejoined the Uchiha clan.</p>
-                            <p>Izumi enrolled in Konoha's Academy a few years later.Like other girls her age, Izumi
+                            <p class="card-text">Izumi enrolled in Konoha's Academy a few years later.Like other girls her age, Izumi
                                 developed a crush on Itachi Uchiha, a boy in the class next to hers.As such, she tried
                                 to talk with him during school breaks, walk home with him after lessons, and defend him
                                 from their peers' criticism. Itachi initially took the same disinterest in Izumi that he
@@ -388,7 +388,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Fūka was portrayed as a seductive vixen as a way to lure her prey in
                                 and kill them with an Execution by Kiss.</p>
-                            <p>She would further speed up the process by giving her targets a choice between a French or
+                            <p class="card-text">She would further speed up the process by giving her targets a choice between a French or
                                 traditional kiss. Her most preferable victims were those with a natural affinity for
                                 wind chakra. She took great pride in her appearance and would become infuriated when any
                                 harm came to her physical being, especially her hair, the very casing of her soul.
@@ -411,7 +411,7 @@
                             <p class="card-text">Rôshi was the last Jinchûriki of Yonbi, the 4-tailed demon. He was
                                 killed by Kisame Hoshigaki, a former member of the Akatsuki, who aimed to reunite all
                                 the Biju.</p>
-                            <p>Rôshi will be resurrected later during the Fourth Great Ninja War by Kabuto Yakushi. He
+                            <p class="card-text">Rôshi will be resurrected later during the Fourth Great Ninja War by Kabuto Yakushi. He
                                 will fight Bee and Naruto.</p>
                         </div>
                     </div>
@@ -432,7 +432,7 @@
                                 and Jugo. Of the quartet, Suigetsu was the self-styled comedian. He had plenty of
                                 sarcastic lines and made every effort he could to get under Karin's skin.
                             </p>
-                            <p>The above line was especially funny coming from Suigetsu, as the audience got the
+                            <p class="card-text">The above line was especially funny coming from Suigetsu, as the audience got the
                                 distinct impression that he probably wasn't a true believer in Sasuke's dream. It was
                                 even funnier in the moment, as he made a decisive gesture with a spoon he was using at
                                 the time.</p>
@@ -515,7 +515,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Yukimaru is a young orphan who became one of Orochimaru's test
                                 subjects, due to his ability to partially control the Three-Tails.</p>
-                            <p>Yukimaru lived with his mother in a village that was attacked by Orochimaru's followers
+                            <p class="card-text">Yukimaru lived with his mother in a village that was attacked by Orochimaru's followers
                                 when Yukimaru was a child.</p>
                         </div>
                     </div>
@@ -535,7 +535,7 @@
                             <p class="card-text">Yamato is a very discreet, cautious, careful and well prepared person.
                                 He projects a calm, stoic demeanour in stressful situations. He takes his missions very
                                 seriously, even insisting on being referred to by whatever his current codename</p>
-                            <p>Yamato is one of the main supporting characters in the Naruto anime/manga series and the
+                            <p class="card-text">Yamato is one of the main supporting characters in the Naruto anime/manga series and the
                                 Boruto: Naruto Next Generations anime/manga series. He is an ANBU in the service of
                                 Konohagakure. Because of his unique jutsu, he is added to Team Kakashi as a temporary
                                 for Kakashi Hatake. Though Kakashi eventually returns to the team, Yamato stays on to
@@ -579,7 +579,7 @@
                                 has become the Fifth Hokage of The Hidden Leaf Village. Her grandparents are revealed to
                                 be Hashirama
                                 Senju and Mito Uzumaki.</p>
-                            <p>Tsunade's trademark ability is her inhuman strength, which is derived from her
+                            <p class="card-text">Tsunade's trademark ability is her inhuman strength, which is derived from her
                                 excellent chakra control. By storing chakra and releasing it at the point of contact,
                                 she can enhance her strength to the point where she can break through boulders her bare
                                 hands. She is also an extremely talented Medical-nin, and can heal wounds that most
@@ -626,7 +626,7 @@
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Hanare (ハナレ, Hanare) is a kunoichi from the Jōmae Village. </p>
-                            <p>As a young child, Hanare was said to be very lonely since she had never known her family
+                            <p class="card-text">As a young child, Hanare was said to be very lonely since she had never known her family
                                 or seen
                                 her own village. She was trained from an early age in the art of espionage. One day, she
                                 was
@@ -660,7 +660,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Fūka was portrayed as a seductive vixen as a way to lure her prey in
                                 and kill them with an Execution by Kiss.</p>
-                            <p>She would further speed up the process by giving her targets a choice between a French or
+                            <p class="card-text">She would further speed up the process by giving her targets a choice between a French or
                                 traditional kiss. Her most preferable victims were those with a natural affinity for
                                 wind chakra. She took great pride in her appearance and would become infuriated when any
                                 harm came to her physical being, especially her hair, the very casing of her soul.
@@ -683,7 +683,7 @@
                             <p class="card-text">The first-ever person whom Naruto faced in a battle in order to know
                                 his power and also get to know about his own ninja way. He thrashed him in the battle
                                 against him while saving Iruka Umino his sensei in his elementary Training Academy</p>
-                            <p> Mizuki duped Naruto Uzumaki into stealing Konoha's Scroll of Seals for him. Originally,
+                            <p class="card-text"> Mizuki duped Naruto Uzumaki into stealing Konoha's Scroll of Seals for him. Originally,
                                 Mizuki had the plan set up to have Naruto as a scapegoat and kill him to hide the truth
                                 of his deception and secretly leave the village with the scroll in his possession.
                                 However, Mizuki's plan is derailed when Iruka found Naruto first and decided to reveal
@@ -708,7 +708,7 @@
                             <p class="card-text">Naruto's first battle against non-Konoha ninja happened at the start of
                                 the Land of Waves Escort Mission arc. Two allies of Zabuza waited outside of Konoha in
                                 order to ambush Tazuna, who was being escorted by Team 7.</p>
-                            <p>These were two former Hidden Mist shinobi, known as the Demon Brothers, who had defected
+                            <p class="card-text">These were two former Hidden Mist shinobi, known as the Demon Brothers, who had defected
                                 from their village in order to join Zabuza's coup.
 
                                 Kakashi and Sasuke were able to easily dispose of the Demon Brothers and keep Tazuna
@@ -737,7 +737,7 @@
                             <p class="card-text">Madara Uchiha was the legendary leader of the Uchiha clan. He founded
                                 Konohagakure alongside his childhood friend and rival, Hashirama Senju, with the
                                 intention of beginning an era of peace.</p>
-                            <p> When the two couldn't agree on how to achieve that peace, they fought for control of the
+                            <p class="card-text"> When the two couldn't agree on how to achieve that peace, they fought for control of the
                                 village, a conflict which ended in Madara's death. Madara, however, rewrote his death
                                 and went into hiding to work on his own plans. Unable to complete it in his natural
                                 life, he entrusted his knowledge and plans to Obito shortly before his actual death.
@@ -758,7 +758,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">A kunoichi from The Hidden Sound Village and a member of The Sound
                                 Five.</p>
-                            <p>Tayuya is one of Orochimaru's Sound Four Ninja. She is foul mouthed and ill tempered yet
+                            <p class="card-text">Tayuya is one of Orochimaru's Sound Four Ninja. She is foul mouthed and ill tempered yet
                                 very powerful. Her only weapon is a flute which she can use to summon three giant demons
                                 known as the Doki. Tayuya is also very intelligent and can think up excellent strategies
                                 and tactics.</p>
@@ -811,7 +811,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Itachi Uchiha is a fictional character in the Naruto manga and anime
                                 series created by Masashi Kishimoto.</p>
-                            <p>Itachi is the older brother of Sasuke Uchiha, and is responsible for killing all the
+                            <p class="card-text">Itachi is the older brother of Sasuke Uchiha, and is responsible for killing all the
                                 members of their clan, sparing only Sasuke. He appears working as a terrorist from the
                                 organisation Akatsuki and serves as Sasuke's greatest enemy. During the second part of
                                 the manga, Itachi becomes involved in attacks to ninjas possessing tailed-beast
@@ -880,7 +880,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Hiashi Hyuga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
                                 well as the current head of the Hyūga clan.</p>
-                            <p>Hiashi was born only seconds before his twin brother Hizashi, making Hiashi the head of
+                            <p class="card-text">Hiashi was born only seconds before his twin brother Hizashi, making Hiashi the head of
                                 the Hyūga clan and Hizashi a member of the branch house, whose only purpose in life
                                 would be to protect members of the main house. Years later, when Neji was born, Hizashi
                                 became bitter that his son would never be able to reach his full potential like a member
@@ -903,7 +903,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Bansai is an elder ninja monk in the Fire Temple as well as the Head
                                 Monk of the temple.</p>
-                            <p>Bansai is a very kind person who cares about his comrades deeply as seen when he said a
+                            <p class="card-text">Bansai is a very kind person who cares about his comrades deeply as seen when he said a
                                 prayer for Asuma Sarutobi before he set out for battle.</p>
                         </div>
                     </div>
@@ -944,7 +944,7 @@
                                 weapon for Kara. He was heavily modified with microscopic Shinobi-Ware implanted in his
                                 body that give him abilities similar to Jugo's Sage Transformation in altering his
                                 physiology at a cellular level.</p>
-                            <p> For reasons yet to be revealed, Kawaki left Kara and encountered Boruto who brings him
+                            <p class="card-text"> For reasons yet to be revealed, Kawaki left Kara and encountered Boruto who brings him
                                 to the Hidden Leaf as he lives with the Uzumaki family. The two would end up becoming
                                 enemies as hinted in prologue of the Boruto series, an older Kawaki appearing to have
                                 perpetrated Konoha's destruction as he confronts an older Boruto while declaring the age
@@ -971,7 +971,7 @@
                                 However, affected by Eida's powers, Boro could not bring himself to complete the task,
                                 and instead hid Eida and Daemon in a remote location operated by his cult for his own
                                 uses.</p>
-                            <p> Eida is a very cold and indifferent person.
+                            <p class="card-text"> Eida is a very cold and indifferent person.
                                 She cares little for the events around her.
                                 This comes from having grown bored in the life that was forced upon her.
                             </p>
@@ -1086,7 +1086,7 @@
                                 peace. Following Yahiko's death, Nagato would turn his body into the
                                 Deva Path of his Six Paths of Pain, which he used as the continued public image of
                                 Akatsuki's leadership.</p>
-                            <p> Yahiko was orphaned during the Second Shinobi World War, forcing him to steal food in
+                            <p class="card-text"> Yahiko was orphaned during the Second Shinobi World War, forcing him to steal food in
                                 order to survive prior to teaming
                                 up with a fellow war orphan named Konan. Soon after they found a place to call home,
                                 Yahiko expressed his displeasure from Konan bringing another war orphan. </p>
@@ -1103,7 +1103,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Deidara is a member of the Akatsuki group, Deidara was partnered with
                                 Sasori before his death, after which he partnered Tobi.</p>
-                            <p>Deidara has a very unique ability, he uses his hands where his palms posses mouths that
+                            <p class="card-text">Deidara has a very unique ability, he uses his hands where his palms posses mouths that
                                 when feed a certain clay explosive can create a flying bird or many small spiders that
                                 can be controlled or control them self after which will explode on command or when they
                                 deem suitable.</p>
@@ -1185,7 +1185,7 @@
                             <p class="card-text">Haku was an orphan from the Land of Water, and a descendant of the Yuki
                                 clan. He later became a shinobi under Zabuza Momochi's tutelage whom he later partnered
                                 with, ultimately becoming a Mercenary Ninja</p>
-                            <p>Haku was a 15-year-old boy with an androgynous appearance and was even viewed as being
+                            <p class="card-text">Haku was a 15-year-old boy with an androgynous appearance and was even viewed as being
                                 beautiful by Naruto, who exclaimed that he was "prettier than Sakura", even after he
                                 informed him that he was male. He had long black hair, pale skin and large, dark-brown
                                 eyes, and a slender frame.</p>
@@ -1205,7 +1205,7 @@
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Tonton is Tsunade's ninja pig, often kept in the care of Shizune.</p>
-                            <p>Above all else, Tonton is a highly devoted, and dutiful pet pig. Her devotion to Tsunade
+                            <p class="card-text">Above all else, Tonton is a highly devoted, and dutiful pet pig. Her devotion to Tsunade
                                 was noted during her master's battle with the other Sannin, which she watched in earnest
                                 as Gamakichi and Gamatatsu bickered. This even surfaced during the Fourth Shinobi World
                                 War, where, in her earnest to aid the Logistical Support and Medical Division, Tonton
@@ -1232,7 +1232,7 @@
                                 Kazekage: Temari, Kankurō and Gaara. Having undergone the gruelling training of their
                                 village, these three are regarded as elite shinobi of their village that excel
                                 in long-range combat. </p>
-                            <p>Some time after the Konoha Crush failed, its members were promoted: Gaara became the
+                            <p class="card-text">Some time after the Konoha Crush failed, its members were promoted: Gaara became the
                                 Kazekage, Kankurō and Temari became jōnin, Temari also becoming an ambassador.In Part
                                 II, Temari and Kankurō attended Gaara to the Five Kage
                                 Summit as his bodyguards.
@@ -1256,7 +1256,7 @@
                             <p class="card-text">Hidan is an S-rank missing-nin who defected from Yugakure and later
                                 joined the Akatsuki. There, he was partnered with Kakuzu,
                                 despite the two's somewhat mutual dislike of each other.</p>
-                            <p>Hidan doesn't always seem like the most intelligent of the Akatsuki. He certainly doesn't
+                            <p class="card-text">Hidan doesn't always seem like the most intelligent of the Akatsuki. He certainly doesn't
                                 have the knack for long-term planning that Pain or Tobi do,
                                 for example. Hidan does, however, much like Kakuzu, have a great understanding of
                                 anatomy and just how shinobi abilities work. That's how he
@@ -1282,7 +1282,7 @@
                                 (Dark sound ninja with horrifying skills and abilities.)
                             </p>
 
-                            <p>
+                            <p class="card-text">
                                 Sakon and Ukon have the ability to when touching there opponent attach there cells to
                                 their opponents, there for, making them one and slowly killing there opponents cells in
                                 place for there own. No one had ever survived it but no one had ever been as
@@ -1308,7 +1308,7 @@
                             <p class="card-text">Zabuza Momochi (桃地再不斬, Momochi Zabuza), given the moniker Demon of the
                                 Hidden Mist (霧隠れの鬼人, Kirigakure no Kijin), was a missing-nin from Kirigakure's Seven
                                 Ninja Swordsmen of the Mist.</p>
-                            <p>As a Hidden Mist ninja, Zabuza's forte is using water-nature chakra to manipulate water
+                            <p class="card-text">As a Hidden Mist ninja, Zabuza's forte is using water-nature chakra to manipulate water
                                 to take in many forms as he wishes such as creating Water Clones. Among his abilities is
                                 the Water Dragon jutsu where he creates a serpentine dragon out of water to consume his
                                 target.</p>
@@ -1331,7 +1331,7 @@
                                 taijutsu as well as ninjas who are considered geniuses like Shikamaru
                                 and Neji. There is one ninja among the eleven, however, who definitely falls short of
                                 the spotlight--Tenten</p>
-                            <p>While Tenten was introduced as a character who specializes in ninja tools and weapons,
+                            <p class="card-text">While Tenten was introduced as a character who specializes in ninja tools and weapons,
                                 there is little that we know about her clan and background. Even in her most well-known
                                 battle against Temari during the Chunin Exams, she
                                 was practically defeated before anyone had a chance to see her true fighting
@@ -1352,7 +1352,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Might Guy (マイト・ガイ, Maito Gai) is a jōnin of Konohagakure. A master of
                                 taijutsu, Guy leads and passes his wisdom onto the members of Team Guy.</p>
-                            <p>Guy is the son of Might Duy, who was known throughout Konoha as the "Eternal Genin". Duy
+                            <p class="card-text">Guy is the son of Might Duy, who was known throughout Konoha as the "Eternal Genin". Duy
                                 was not bothered by this moniker and instead was grateful that other people cared enough
                                 to know him at all. Duy encouraged this same kind of optimism in Guy, as well as his
                                 belief that one always has youth and that they could both become taijutsu masters
@@ -1379,7 +1379,7 @@
                                 until he meets his end by the Akatsuki Member, Hidan. He was later resurrected with the
                                 impure world resurrection technique to participate
                                 in the Fourth Shinobi World War.</p>
-                            <p>His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
+                            <p class="card-text">His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
                                 team which served to protect the Land of Fire's daimyō — a role which later earned him a
                                 bounty of 35,000,000 ryō.[9][21] He could effortlessly
                                 take down nine Oto-nin during the Konoha Crush, noted to have been chūnin-level or
@@ -1403,7 +1403,7 @@
                                 member of the Way of Jashin (ジャシン, lit. "evil god") religion which
                                 worships a deity of the same name and believes that anything less than death and utter
                                 destruction in battle is a sin.</p>
-                            <p>Hidan can create a link with his opponent. Once this link is created, any damage done to
+                            <p class="card-text">Hidan can create a link with his opponent. Once this link is created, any damage done to
                                 Hidan's body is reflected on his opponent, allowing him to kill them by giving himself
                                 fatal injuries. Though his immortality keeps him
                                 from dying or suffer any impairment, Hidan feels his victims' suffering with an
@@ -1429,7 +1429,7 @@
                                 village. He is the teacher (sensei) of Uzumaki Naruto, Haruno Sakura and Uchiha Sasuke.
                                 His teacher was the fourth hokage, Minato Namikaze and his teammates
                                 were Obito Uchiha and Rin Nohara. His rival is Might Guy.</p>
-                            <p>He's worked and thrived at all levels, including among the ANBU. He has a summoning
+                            <p class="card-text">He's worked and thrived at all levels, including among the ANBU. He has a summoning
                                 ability with a pack of Ninja Dogs, one of which speaks and all of which are excellent
                                 trackers. He's never been shown without his masks on.
                                 He wears at least two of them, and even his close friends don't know what he looks like.
@@ -1452,7 +1452,7 @@
                                 was the head of the Uchiha clan as well as the leader of the Konoha Military Police
                                 Force.
                             </p>
-                            <p>Fugaku Uchiha was as strong as fourth hokage Minato Namikaze. Let's talk about the great
+                            <p class="card-text">Fugaku Uchiha was as strong as fourth hokage Minato Namikaze. Let's talk about the great
                                 ninja war. Minato killed an 1000 strong army using the “flying thunder god" ie hirashino
                                 jutsu. In that same war Fugaku killed countless
                                 using genjutsu alone. One of his comrades died covering him and he unlocked the Mangekyo
@@ -1474,7 +1474,7 @@
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
-                            <p>Inari is the son of Tsunami, and is also Tazuna's grandson. His biological father died
+                            <p class="card-text">Inari is the son of Tsunami, and is also Tazuna's grandson. His biological father died
                                 before he got to know him.
                             </p>Inari first appeared to be a very tough individual, though this was just a ruse he put
                             on to hide the loneliness he felt since the death of Kaiza. He would often spend most of his
@@ -1497,13 +1497,13 @@
                             <p class="card-text">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
                                 Lightning Shadow) of Kumogakure, was renowned to be the greatest Raikage the village has
                                 ever had.</p>
-                            <p>The Third Raikage's rule was punctuated by the berserk attacks of the Eight-Tails but as
+                            <p class="card-text">The Third Raikage's rule was punctuated by the berserk attacks of the Eight-Tails but as
                                 Kumogakure couldn't afford to dispose of such a valuable war deterrent, he was forced to
                                 look for a suitable jinchūriki in quick succession, after the conclusion of each
                                 rampage. During one of these attacks, he fought the Eight-Tails alone, allowing his
                                 comrades to escape. Their battle resulted in him receiving a self-inflicted wound to the
                                 chest after he collapsed upon his own hand, which became his life's shame.</p>
-                            <p>Since this event, he made it a personal duty to combat the Eight-Tails whenever its
+                            <p class="card-text">Since this event, he made it a personal duty to combat the Eight-Tails whenever its
                                 jinchūriki lost control, eventually making even his son become part of the group that
                                 supported him during these occurrences. He chose to seal the Eight-Tails in the Kohaku
                                 no Jōhei, resulting in his nephew's death, hoping that someone else would have more
@@ -1526,7 +1526,7 @@
                             <p class="card-text">Mikoto Uchiha (うちはミコト, Uchiha Mikoto) was a jōnin from Konohagakure's
                                 Uchiha clan.
                             </p>
-                            <p>Mikoto was a very gentle and kind woman, but could also be stern and strict when she
+                            <p class="card-text">Mikoto was a very gentle and kind woman, but could also be stern and strict when she
                                 needed to be, as seen when Itachi came back from the Academy and she told Sasuke that he
                                 could not play because he had homework. She loved
                                 her sons deeply and knew how to help them with their problems. Mikoto cared for and also
@@ -1555,7 +1555,7 @@
                                 posed as Madara Uchiha's manifested will and then partnered with White Zetsu to become
                                 half of the Akatsuki member known simply as Zetsu (ゼツ, Zetsu).
                             </p>
-                            <p>Black Zetsu was created by Kaguya Ōtsutsuki shortly before she was sealed as the
+                            <p class="card-text">Black Zetsu was created by Kaguya Ōtsutsuki shortly before she was sealed as the
                                 Ten-Tails by her twin sons, Hagoromo and Hamura. In the anime, Black Zetsu would
                                 approach Indra alone periodically, goading him with praises and
                                 curiosity towards Indra's true potential, even going so far as to say he could rival if
@@ -1586,7 +1586,7 @@
                                 Senju, the village's First Hokage, and later became the first jinchūriki
                                 of the Nine-Tails following the events at the Valley of the End.
                             </p>
-                            <p>The Uzumaki and Senju clans — being distant relatives — have always had close ties. Mito
+                            <p class="card-text">The Uzumaki and Senju clans — being distant relatives — have always had close ties. Mito
                                 ended up marrying Hashirama Senju, who would help found Konohagakure and became the
                                 village's First Hokage. After Hashirama's victory
                                 against Madara Uchiha at the Valley of the End and obtaining Kurama from him, Mito
@@ -1612,7 +1612,7 @@
                                 group of Orochimaru's subordinates,
                                 possessing the unique Crystal Release kekkei genkai.
                             </p>
-                            <p>she was offered the chance to become one of Orochimaru's future vessels. When Sasuke
+                            <p class="card-text">she was offered the chance to become one of Orochimaru's future vessels. When Sasuke
                                 Uchiha defected from Konohagakure and Kimimaro was no longer a
                                 suitable vessel for Orochimaru, Guren became the next best choice in Orochimaru's eyes.
                                 Unfortunately, by the time she arrived, Orochimaru couldn't
@@ -1638,7 +1638,7 @@
                                 no Hanzō),
                                 was a legendary shinobi, and the leader of Amegakure during his lifetime.
                             </p>
-                            <p>At some point during Hanzō's childhood, he found a black salamander with deadly venom
+                            <p class="card-text">At some point during Hanzō's childhood, he found a black salamander with deadly venom
                                 residing in his village.
                                 When it died, its venom sac was embedded into his body in the hopes of creating a
                                 venomous ninja who himself was immune to toxins.
@@ -1668,7 +1668,7 @@
                                 by his name. After Nagato's death, Konan defected from Akatsuki and became the de facto
                                 village head of Amegakure.
                             </p>
-                            <p>When she was young, Konan's family was killed during the Second Shinobi World War, and
+                            <p class="card-text">When she was young, Konan's family was killed during the Second Shinobi World War, and
                                 she was left to fend for herself.[4] Some time later, Yahiko found her, and the two
                                 worked together to survive. Not long after that, Konan
                                 went for a walk and found a young, dying Nagato and his dog, Chibi. She rescued him and
@@ -1695,7 +1695,7 @@
                         <div class="flip-card-back">
 
                             <p class="card-text">A ninja from The Hidden Sound Village and member of The Sound Five.</p>
-                            <p>Kidomaru was killed fighting against Neji Hyuga</p>
+                            <p class="card-text">Kidomaru was killed fighting against Neji Hyuga</p>
                         </div>
                     </div>
                 </div>
@@ -1711,7 +1711,7 @@
 			    </div>
 			    <div class="flip-card-back">
 				<p class="card-text">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
-				<p>Karin has been praised for her abilities by both Obito Uchiha and Orochimaru, the latter deciding to take her with him for that reason. Despite being mostly a non-combatant, Orochimaru referred to Karin as one of his good experiments,[4] and had enough faith in her skills to put her in charge of the Southern Hideout's prison, since she made escaping impossible. Karin later demonstrated these skills most predominantly during the Fourth Shinobi World War, where she destroyed much of Tobi's giant wooden statue.</p>
+				<p class="card-text">Karin has been praised for her abilities by both Obito Uchiha and Orochimaru, the latter deciding to take her with him for that reason. Despite being mostly a non-combatant, Orochimaru referred to Karin as one of his good experiments,[4] and had enough faith in her skills to put her in charge of the Southern Hideout's prison, since she made escaping impossible. Karin later demonstrated these skills most predominantly during the Fourth Shinobi World War, where she destroyed much of Tobi's giant wooden statue.</p>
 			    </div>
 			</div>
 		    </div>
@@ -1731,7 +1731,7 @@
                             <p class="card-text">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
                                 specialises in training elite ninja. He also served as the leader of Team Ebisu, which
                                 consisted of Konohamaru Sarutobi, Udon, and Moegi.</p>
-                            <p>Ebisu is portrayed as a stern and "by-the-book" type of person. Initially, he expressed
+                            <p class="card-text">Ebisu is portrayed as a stern and "by-the-book" type of person. Initially, he expressed
                                 hatred for Naruto Uzumaki, and believed he was nothing but a worthless nuisance and
                                 mocked his dream of becoming Hokage as he believes
                                 that only people of high lineage could amount to anything. Upon seeing what Naruto had
@@ -1763,7 +1763,7 @@
                                 the village system work, thus ensuring Konoha's continuity and prosperity. After his
                                 brother's death, he would earn the title of Second
                                 Hokage (二代目火影, Nidaime Hokage, literally meaning: Second Fire Shadow).</p>
-                            <p>Like Hashirama before him, Tobirama tried to foster good relations with the other
+                            <p class="card-text">Like Hashirama before him, Tobirama tried to foster good relations with the other
                                 villages. He planned an alliance between Konoha and Kumogakure, but during a formal
                                 ceremony he and the Second Raikage were attacked by the Gold
                                 and Silver Brothers and left near death. During the First Shinobi World War, Team
@@ -1788,7 +1788,7 @@
                                 twin brother, Hizashi, and thereby making Hiashi head of the clan
                                 while Hizashi is demoted to the Branch House whose only purpose is to serve the upper
                                 branch.</p>
-                            <p>Hinata also meets Naruto Uzumaki during her youth, developing an interest in him after he
+                            <p class="card-text">Hinata also meets Naruto Uzumaki during her youth, developing an interest in him after he
                                 defends her while she is being bullied because of her eyes.[25] That event and Naruto's
                                 refusal to give up against adversity inspire
                                 Hinata to become a stronger person. However, Hinata's admiration for Naruto gradually
@@ -1808,7 +1808,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
                                 well as the current head of the Hyūga clan.</p>
-                            <p>Hiashi was born just seconds before his twin brother Hizashi, which makes Hiashi the mind
+                            <p class="card-text">Hiashi was born just seconds before his twin brother Hizashi, which makes Hiashi the mind
                                 of this Hyūga clan. Since the leader of the Hyūga clan, Hiashi is undoubtedly a strong
                                 shinobi. He's well-versed in all of his clan's secret procedures and fighting style.
 
@@ -1838,7 +1838,7 @@
                                 until he meets his end by the Akatsuki Member, Hidan. He was later resurrected with the
                                 impure world resurrection technique to participate
                                 in the Fourth Shinobi World War.</p>
-                            <p>His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
+                            <p class="card-text">His abilities earned him a position into the Twelve Guardian Ninja — an elite hand-picked
                                 team which served to protect the Land of Fire's daimyō — a role which later earned him a
                                 bounty of 35,000,000 ryō.[9][21] He could effortlessly
                                 take down nine Oto-nin during the Konoha Crush, noted to have been chūnin-level or
@@ -1915,7 +1915,7 @@
                             <p class="card-text">The First hokage, leader of the Senju clan, one of the founders of
                                 Konohagakure. Older brother to the Second Hokage and Grandfather to the Fifth Hokage. He
                                 possesses the Wood Style and has a friend and rival called Madara Uchiha.</p>
-                            <p>He also showed great tactical skill and deceptive abilities, waiting until Madara became
+                            <p class="card-text">He also showed great tactical skill and deceptive abilities, waiting until Madara became
                                 so exhausted that he couldn't maintain his Sharingan to create a wood clone for Madara
                                 to strike down so he could attack from behind without
                                 his opponent even realising it.</p>
@@ -1934,7 +1934,7 @@
                             <p class="card-text">Kaguya was the originator of shinobi in the world in which Naruto takes
                                 place. She was once benevolent and respected, but became corrupted. She is the final
                                 villain to oppose Naruto's team in the manga.</p>
-                            <p>The final boss of Naruto turned out to be a woman! Who could've seen that coming?! One
+                            <p class="card-text">The final boss of Naruto turned out to be a woman! Who could've seen that coming?! One
                                 would begin to wonder if Kishimoto had finally turned over a new leaf and realized that
                                 women too can be characters who can be a lot more
                                 beyond their gender. But alas, such hopes were dashed immediately when fans realized
@@ -1958,7 +1958,7 @@
                             <p class="card-text">Killer B is a major supporting character in the anime and manga Naruto
                                 Shippuden. He is the host of Gyuki, The Eight-tailed demon Ox. He was a shinobi who
                                 trained Naruto and is partners with him while fighting Obito Uchiha.</p>
-                            <p>Killer B (キラービー, Kirā Bī, Viz: Killer Bee) is a shinobi from Kumogakure. He is the most
+                            <p class="card-text">Killer B (キラービー, Kirā Bī, Viz: Killer Bee) is a shinobi from Kumogakure. He is the most
                                 recent jinchūriki of the Eight-Tails, Gyūki, though, unlike his predecessors, he was
                                 able to befriend it and hone its power for Kumo's benefit. Despite being responsible for
                                 the village's protection, B aspires to be the world's greatest rapper.</p>
@@ -1979,7 +1979,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Gamabunta is a grumpy, stubborn and highly apathetic toad. He was
                                 summoned by lord fourth Hokage , sensei Jiraiya and by Naruto.</p>
-                            <p>Gamabunta can spew oil from his mouth and use it to enhance fire. He is one of the
+                            <p class="card-text">Gamabunta can spew oil from his mouth and use it to enhance fire. He is one of the
                                 biggest summon animal in the series. He was firest summoned by naruto when he was
                                 Falling from potential death.</p>
                         </div>
@@ -2000,7 +2000,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">The ten-tailed beast was created by Kaguya Otsutsuki and later had its
                                 chakra split into the nine tailed beasts.</p>
-                            <p>The Ten-Tailed Beast (十尾, Jūbi) is the original, primordial demon of the Naruto universe.
+                            <p class="card-text">The Ten-Tailed Beast (十尾, Jūbi) is the original, primordial demon of the Naruto universe.
                                 All nine of the tailed beasts are but portions of chakra divided from the Ten-Tails.
                                 madara uchiha's ultimate goal, the moon's eye plan, is to capture and merge all nine of
                                 the tailed beasts back into the Ten-Tails, and become its host to cast the reflection of
@@ -2021,7 +2021,7 @@
                         <div class="flip-card-back">
                             <p class="card-text">Matatabi also known as Two-Tails, is one of the nine tailed
                                 beast.Yugito Nii is the jinchūriki of her</p>
-                            <p>Matatabi has shown to be respectful and polite towards others,she is completely engulfed
+                            <p class="card-text">Matatabi has shown to be respectful and polite towards others,she is completely engulfed
                                 in blue flames.Matatabi also has flexible muscles, which grant it great speed despite
                                 its large size
                             </p>
@@ -2238,7 +2238,7 @@
                             <p class="card-text">As a teenager 34 years before the Fourth Shinobi World
                                 War, Teuchi devoted his life to making
                                 ramen. More than a decade later, he had a daughter called Ayame.</p>
-                            <p>Teuchi is a very kind and jovial man. Often seen smiling, he and Ayame
+                            <p class="card-text">Teuchi is a very kind and jovial man. Often seen smiling, he and Ayame
                                 have always treated Naruto Uzumaki well,
                                 considering him their best customer, sometimes even giving him free
                                 ramen on special occasions.
@@ -2346,7 +2346,7 @@
                                 class="img_card">
                         </div>
                         <div class="flip-card-back">
-                            <p>Kisame Hoshigaki (干柿 鬼鮫, Hoshigaki Kisame) is a former ninja
+                            <p class="card-text">Kisame Hoshigaki (干柿 鬼鮫, Hoshigaki Kisame) is a former ninja
                                 of Kirigakure and partnered to Itachi Uchiha, having a
                                 unique appearance with pale blue skin, a gill-like facial
                                 structure, and sharp triangular teeth. While he was loyal to
@@ -2386,7 +2386,7 @@
                     </div>
                     <div class="flip-card-back">
                         <p class="card-text">The Gold and Silver Brothers (金銀兄弟, Kingin Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no Hikari), were two infamous shinobi from Kumogakure, that were distantly related to the Sage of Six Paths.</p>
-                        <p>They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
+                        <p class="card-text">They were the ones who attacked Tobirama, the Second Hokage, and A, the Second Raikage, during an alliance meeting and tried to steal the Nine-tails for themselves. Later they were eaten by the Nine-Tailed Demon Fox and the brothers ate the meat inside the demon fox to stay alive but they acquired a piece of the fox's chakra.
    </div>
                     </div>
                 </div>
@@ -2406,7 +2406,7 @@
                                 Kyōdai), also known as the "Two Lights" (二つの光, Futatsu no
                                 Hikari), were two infamous shinobi from Kumogakure, that
                                 were distantly related to the Sage of Six Paths.</p>
-                            <p>They were the ones who attacked Tobirama, the Second Hokage,
+                            <p class="card-text">They were the ones who attacked Tobirama, the Second Hokage,
                                 and A, the Second Raikage, during an alliance meeting and
                                 tried to steal the Nine-tails for themselves. Later they
                                 were eaten by the Nine-Tailed Demon Fox and the brothers ate
@@ -2433,7 +2433,7 @@
                             <p class="card-text">The Asura Path (修羅道) grants the user the
                                 ability to augment their own body to summon mechanised
                                 armour and various ballistic and mechanical weaponry.</p>
-                            <p>Through the Asura Path, the user is able to form up to four
+                            <p class="card-text">Through the Asura Path, the user is able to form up to four
                                 additional arms and two additional faces, as well as a
                                 folded, serrated blade-like sash around their waist.</p>
                         </div>
@@ -2453,7 +2453,7 @@
                         <p class="card-text">A (エー, Ē, Viz: Ei, English TV: Ay) was the First Raikage (初代雷影, Shodai Raikage, literally meaning:
                              First or Founding Lightning Shadow) who founded Kumogakure in the Land of Lightning.During his leadership in the early days of Kumogakure after the Warring States Period,
                               A presumably sent the Gold and Silver Brothers to capture the Nine-Tails, a task at which they ultimately failed.
-                        <p>While not much was seen of his personality, A did seemingly have a verbal tic, ending his sentences with "yo" (よ).
+                        <p class="card-text">While not much was seen of his personality, A did seemingly have a verbal tic, ending his sentences with "yo" (よ).
                             He also seemed to have a habit of folding his arms. He was a prideful man and held the idea that shinobi shouldn't lower their heads so easily.
                             A had a strong will to protect Kumogakure, something he passed down to his successor.</p>
                     </div>
@@ -2474,7 +2474,7 @@
                             Eventually, his long service and dedication earned him the appointment of Second Raikage.
                              During his tenure, A entered Kumogakure into a formal alliance with Konohagakure, however, during the ceremony both he, and the Second Hokage were ambushed by the Gold and Silver Brothers, who were attempting to stage a coup d'état.
                               It is unknown what happened to A, but the Hokage was said to have barely escaped with his life.Overall A's actions helped Kumogakure a lot in the way of achieving peace.
-                        <p>A inherited the strong will of his predecessor to protect Kumogakure. He was also described as being friendly and intelligent, seen by his versed knowledge in politics</p>
+                        <p class="card-text">A inherited the strong will of his predecessor to protect Kumogakure. He was also described as being friendly and intelligent, seen by his versed knowledge in politics</p>
                     </div>
                 </div>
             </div>
@@ -2493,7 +2493,7 @@
                              During one of these attacks, A fought the Eight-Tails alone, allowing his comrades to escape. Their battle resulted in A receiving a self-inflicted wound to the chest after he collapsed upon his own hand, which became his life's shame.
                              Since this event, he made it a personal duty to combat the Eight-Tails whenever its jinchūriki lost control, eventually making even his son become part of the group that supported him during these occurrences. 
                              He chose to seal the Eight-Tails in the Kohaku no Jōhei, resulting in his nephew's death, hoping that someone else would have more success in controlling it.
-                        <p>A is a calm and seemingly level-headed person. He is also a man of honour as seen when he became outraged when Mū urges Ōnoki to take advantage of the Allied Shinobi Forces after it is disbanded, telling him that he wouldn't allow the alliance to become destroyed. 
+                        <p class="card-text">A is a calm and seemingly level-headed person. He is also a man of honour as seen when he became outraged when Mū urges Ōnoki to take advantage of the Allied Shinobi Forces after it is disbanded, telling him that he wouldn't allow the alliance to become destroyed. 
                             He is also a very proud and caring individual who will readily use himself as a shield or "go-between" to protect his comrades. This was also exemplified when it was revealed that after he received a scar from fighting the Eight-Tails, not even his son asked him about it in detail, out of his respect for his father's pride.
                             A was also a firm believer of children being destined to surpass their parents, so much so he told his fellow Kage who were reincarnated not to worry about being forced to fight against their fellow shinobi as their children would be able to defeat them.</p>
                     </div>

--- a/style.css
+++ b/style.css
@@ -378,10 +378,10 @@ h1 {
 .card {
   overflow: clip;
 }
-.flip-card img{
+.flip-card__image {
   max-height: 300px;
 }
-.card img:hover {
+.card__image:hover {
   transform: scale(1.1);
   transition: all 0.3s ease-out;
 }
@@ -696,7 +696,7 @@ button#scrolltopBtn {
 }
 
 /* This container is needed to position the front and back side */
-.flip-card-inner {
+.flip-card__inner {
 
   
   position: relative;
@@ -710,12 +710,12 @@ button#scrolltopBtn {
 }
 
 /* Do an horizontal flip when you move the mouse over the flip box container */
-.flip-card:hover .flip-card-inner {
+.flip-card:hover .flip-card__inner {
   transform: rotateY(180deg);
 }
 
 /* Position the front and back side */
-.flip-card-front, .flip-card-back {
+.flip-card__front, .flip-card__back {
   margin: 70px 0;
   box-shadow: 0 5px 24px 0 rgb(0 0 0 / 80%);
   border-radius: 29px;
@@ -725,19 +725,19 @@ button#scrolltopBtn {
   -webkit-backface-visibility: hidden; /* Safari */
   backface-visibility: hidden;
 }
-.flip-card-back{
+.flip-card__back{
   overflow-y: scroll;
 }
 
 /* Style the front side (fallback if image is missing) */
-.flip-card-front {
+.flip-card__front {
   padding: 0px 10px;
   background-color:rgb(228 212 212);
   color: black;
 }
 
 /* Style the back side */
-.flip-card-back {
+.flip-card__back {
   background-color: rgb(228 212 212);
   color:#000;
   transform: rotateY(180deg);
@@ -748,7 +748,7 @@ button#scrolltopBtn {
 
 }
 
-.flip-card-back::-webkit-scrollbar{
+.flip-card__back::-webkit-scrollbar{
         display: none;
 }
 


### PR DESCRIPTION
Fix issues #986 and #987, about the random use of the classes `card-text` and `img_card`, and about the non-existent use of a nomenclature in css styles.