### PR TITLE
fix(data): missing character names on the `alt` attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Naruto Uzumaki</h2>
-                            <img src="./Images/naruto.png" alt="naruto" height="330px" width="300px">
+                            <img src="./Images/naruto.png" alt="Naruto" height="330px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Naruto Uzumaki is the main protagonist in the popular manga and anime
@@ -226,7 +226,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Sai Yamanaka</h2>
-                            <img src="./Images/Sai_Infobox.png" alt="Sai" height="300px" width="300px">
+                            <img src="./Images/Sai_Infobox.png" alt="Sai Yamanaka" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Sai Yamanaka (山中サイ, Yamanaka Sai) is the Anbu Chief of
@@ -296,7 +296,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ten Tails - Juubi</h2>
-                            <img src="./Images/ten tails.jpeg" alt="Ten Tails" height="300px" width="300px">
+                            <img src="./Images/ten tails.jpeg" alt="Ten Tails - Juubi" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">This Ten-Tails (十尾, Jūbi) is the combined form of Kaguya Ōtsutsuki and
@@ -317,7 +317,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Eight Tails - Gyuki</h2>
-                            <img src="./Images/Gyuki-Eight-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
+                            <img src="./Images/Gyuki-Eight-Tails-in-Naruto.webp" alt="Eight Tails - Gyuki" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -340,7 +340,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Seven-Tails - Chomei</h2>
-                            <img src="./Images/Chomei-Seven-Tails-in-Naruto.webp" alt="Ten Tails" height="300px"
+                            <img src="./Images/Chomei-Seven-Tails-in-Naruto.webp" alt="Seven Tails - Chomei" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -490,7 +490,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Boruto Uzumaki</h2>
 
-                            <img src="./Images/boruto.jpg" alt="boruto" height="350px" width="380px">
+                            <img src="./Images/boruto.jpg" alt="Boruto Uzumaki" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Boruto Uzumaki (うずまきボルト, Uzumaki Boruto) is a shinobi from
@@ -510,7 +510,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Uchiha Madara</h2>
-                            <img src="./Images/madara.jpg" alt="boruto" height="350px" width="380px">
+                            <img src="./Images/madara.jpg" alt="Uchiha Madara" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">
@@ -536,7 +536,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ebisu</h2>
-                            <img src="./Images/Ebisu.png" alt=Ebisu height="300px" width="300px">
+                            <img src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Specializes in the private training of Ninja, and is
@@ -553,7 +553,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Yukimaru </h2>
 
-                            <img src="./Images/yukimaru.png" alt="Haku" height="350px" width="380px">
+                            <img src="./Images/yukimaru.png" alt="Yukimaru" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Yukimaru is a young orphan who became one of Orochimaru's test
@@ -571,7 +571,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Yamato</h2>
-                            <img src="./Images/Yamato.png" alt=Yamato height="300px" width="300px">
+                            <img src="./Images/Yamato.png" alt="Yamato" height="300px" width="300px">
 
                         </div>
                         <div class="flip-card-back">
@@ -609,7 +609,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Tsunade</h2>
-                            <img src="Images/Tsunade.jpg" alt=Tsunade height="300px" width="300px">
+                            <img src="Images/Tsunade.jpg" alt="Tsunade" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Tsunade is a kunoichi from the Hidden Leaf Village and posses
@@ -646,7 +646,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Jirobo</h2>
                             <img src="https://www.giantbomb.com/a/uploads/scale_small/0/5756/330799-jirobo.jpg"
-                                alt=Kawaki height="300px" width="300px">
+                                alt="Jirobo" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">A ninja from The Hidden Sound Village and member of The Sound Five.he
@@ -744,7 +744,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">The Demon Brothers</h2>
-                            <img src="Images/Naruto-Demon-Brothers.jpg" alt=[name of character] height="300px"
+                            <img src="Images/Naruto-Demon-Brothers.jpg" alt="The Demon Brothers" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -796,7 +796,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Tayuya</h2>
-                            <img src="./Images/tayuya.jpg" alt="Tayuya Image" height="300px" width="300px">
+                            <img src="./Images/tayuya.jpg" alt="Tayuya" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">A kunoichi from The Hidden Sound Village and a member of The Sound
@@ -978,7 +978,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kawaki</h2>
 
-                            <img src="./Images/kawaki2.jpg" alt="kawaki" height="300px" width="300px">
+                            <img src="./Images/kawaki2.jpg" alt="Kawaki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kawaki (カワキ, Kawaki) is a tattooed youth who became a member of Kara
@@ -1071,7 +1071,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">YAMATO</h2>
 
-                            <img src="./Images/yamato.png" alt="Nagato Uzumaki" height="350px" width="380px">
+                            <img src="./Images/yamato.png" alt="Yamato" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Seeing how pivotal of a role Kakashi played as the leader of Team Seven
@@ -1097,7 +1097,7 @@
                             <h2 class="card-title">Hashirama Senju </h2>
 
                             <img src=https://www.giantbomb.com/a/uploads/scale_small/3/33873/1727699-first_hokage.jpg
-                                alt="Hashirama Senju image" height="300px" width="300px">
+                                alt="Hashirama Senju" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">The First hokage, leader of the Senju clan, one of the founders of
@@ -1121,7 +1121,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Yahiko </h2>
 
-                            <img src="./Images/Yahiko.png" alt="anko" height="350px" width="380px">
+                            <img src="./Images/Yahiko.png" alt="Yahiko" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Yahiko (弥彦, Yahiko) was a shinobi from Amegakure. Alongside his fellow
@@ -1162,7 +1162,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title"> Tsuande </h2>
 
-                            <img src="./Images/Tsunadexx.png" alt="anko" height="350px" width="380px">
+                            <img src="./Images/Tsunadexx.png" alt="Tsuande" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Tsunade (綱手, Tsunade) is a descendant of the Senju and Uzumaki Clan,
@@ -1182,7 +1182,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">KIMIMARO</h2>
 
-                            <img src="./Images/kimimaro.png" alt="kimimaro" height="350px" width="380px">
+                            <img src="./Images/kimimaro.png" alt="Kimimaro" height="350px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">
@@ -1316,7 +1316,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Sakon & Ukon</h2>
 
-                            <img src="./Images/sakon_ukon.jpg" alt="sakon and ukon" height="350px" width="250px">
+                            <img src="./Images/sakon_ukon.jpg" alt="Sakon and Ukon" height="350px" width="250px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">
@@ -1345,7 +1345,7 @@
                             <h2 class="card-title">Zabuza</h2>
 
                             <img src="https://www.giantbomb.com/a/uploads/square_small/0/534/178998-zabuza.jpg"
-                                alt=Zabuza height="300px" width="300px">
+                                alt="Zabuza" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Zabuza Momochi (桃地再不斬, Momochi Zabuza), given the moniker Demon of the
@@ -1465,7 +1465,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kakashi Hatake</h2>
 
-                            <img src="./Images/kakashi.jpg" alt="Naruto Uzumaki" height="300px" width="300px">
+                            <img src="./Images/kakashi.jpg" alt="Kakashi Hatake" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
@@ -1513,7 +1513,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Inari</h2>
 
-                            <img src="./Images/inari.png" alt="Fugaku" height="300px" width="300px">
+                            <img src="./Images/inari.png" alt="Inari" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Inari (イナリ, Inari) is a young citizen of the Land of Waves. </p>
@@ -1534,7 +1534,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Third Raikage</h2>
 
-                            <img src="Images/Raikage3.png" alt="Fugaku" height="300px" width="300px">
+                            <img src="Images/Raikage3.png" alt="Third Raikage" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">The Third Raikage (三代目雷影, Sandaime Raikage, literally meaning: Third
@@ -1562,7 +1562,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Mikoto Uchiha</h2>
 
-                            <img src="https://wallpapercave.com/wp/wp4126361.png" alt="Mikoto" height="300px"
+                            <img src="https://wallpapercave.com/wp/wp4126361.png" alt="Mikoto Uchiha" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1588,7 +1588,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Black Zetsu</h2>
 
-                            <img src="https://wallpapercave.com/wp/wp8345725.jpg" alt="BlackZetsu" height="300px"
+                            <img src="https://wallpapercave.com/wp/wp8345725.jpg" alt="Black Zetsu" height="300px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1621,7 +1621,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Mito Uzumaki</h2>
 
-                            <img src="./Images/MitoUzumaki.jpg" alt="Mito" height="300px" width="300px">
+                            <img src="./Images/MitoUzumaki.jpg" alt="Mito Uzumaki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Mito Uzumaki (うずまきミト, Uzumaki Mito) was a kunoichi who originated from
@@ -1674,7 +1674,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hanzō</h2>
 
-                            <img src="./Images/Hanzo-the-Salamander.jpg" alt="HANZO" height="300px" width="300px">
+                            <img src="./Images/Hanzo-the-Salamander.jpg" alt="Hanzō" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Hanzō (半蔵, Hanzō), feared as Hanzō of the Salamander (山椒魚の半蔵, Sanshōuo
@@ -1750,7 +1750,7 @@
 			<div class="flip-card-inner">
 			    <div class="flip-card-front">
 				<h2 class="card-title">Karin</h2>
-				<img src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt=Karin height="300px" width="300px" class="img_card">
+				<img src=https://static.wikia.nocookie.net/naruto/images/7/72/Karin3.png/revision/latest/scale-to-width-down/300?cb=20170906102126 alt="Karin" height="300px" width="300px" class="img_card">
 			    </div>
 			    <div class="flip-card-back">
 				<p class="card-text">Karin (香燐, Karin) is a subordinate of Orochimaru, a former kunoichi of Kusagakure, and a member of the Uzumaki clan.[3][4] She assisted Orochimaru in his experiments, and was left in charge as warden of his Southern Hideout while he was away. She was later recruited into Sasuke Uchiha's group Taka, which was initially called "Hebi" at the time of its creation.</p>
@@ -1768,7 +1768,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Ebisu Sensei</h2>
 
-                            <img src="./Images/Ebisu.png" alt="Ebisu" height="300px" width="300px">
+                            <img src="./Images/Ebisu.png" alt="Ebisu Sensei" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Ebisu (エビス, Ebisu) is a tokubetsu jōnin from Konohagakure who
@@ -1796,7 +1796,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Tobirama Senju</h2>
 
-                            <img src="./Images/tobirama senju.png" alt="Ebisu" height="300px" width="300px">
+                            <img src="./Images/tobirama senju.png" alt="Tobirama Senju" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Tobirama Senju (千手扉間, Senju Tobirama) was a member of the renowned
@@ -1823,7 +1823,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hinata Hyuga</h2>
 
-                            <img src="./Images/hinata.jpeg" alt="Hinata" height="300px" width="300px">
+                            <img src="./Images/hinata.jpeg" alt="Hinata Hyuga" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Hinata, the eldest of Hiashi Hyuga's two children, is raised as the
@@ -1846,7 +1846,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hiashi Hyuga</h2>
 
-                            <img src="./Images/hiashi.jpeg" alt="Hiashi" height="300px" width="300px">
+                            <img src="./Images/hiashi.jpeg" alt="Hiashi Hyuga" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Hiashi Hyūga (日向ヒアシ, Hyūga Hiashi) is a shinobi from Konohagakure, as
@@ -1938,7 +1938,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Izuna Uchiha</h2>
 
-                            <img src="./Images/Izuna_Uchiha.png" alt="Madara Uchiha" height="300px" width="300px">
+                            <img src="./Images/Izuna_Uchiha.png" alt="Izuna Uchiha" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Izuna Uchiha (うちはイズナ, Uchiha Izuna) was a shinobi of the Uchiha clan.
@@ -1971,7 +1971,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kaguya Otsutsuki</h2>
 
-                            <img src="./Images/Kaguya_Ōtsutsuki.png" alt=" " height="300px" width="300px">
+                            <img src="./Images/Kaguya_Ōtsutsuki.png" alt="Kaguya Otsutsuki" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kaguya was the originator of shinobi in the world in which Naruto takes
@@ -2082,7 +2082,7 @@
 
                             <h2 class="card-title">Obito Uchiha </h2>
 
-                            <img src="https://wallpaperaccess.com/full/5536097.jpg" alt=Obito height="300px"
+                            <img src="https://wallpaperaccess.com/full/5536097.jpg" alt="Obito Uchiha" height="300px"
                                 width="300px">
 
                         </div>
@@ -2121,7 +2121,7 @@
 
                             <h2 class="card-title">Rin Nohara </h2>
 
-                            <img src="Images/Rin_Nohara.jpg" alt=Rin height="300px" width="300px">
+                            <img src="Images/Rin_Nohara.jpg" alt="Rin Nohara" height="300px" width="300px">
 
                         </div>
 
@@ -2149,7 +2149,7 @@
                             <h2 class="card-title">Jiraiya</h2>
 
                             <img src="https://www.giantbomb.com/a/uploads/scale_super/9/95613/2225257-jiraiya.jpg"
-                                alt=Jiraiya height="300px" width="300px">
+                                alt="Jiraiya" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <h2 class="card-title">Jiraiya</h2>
@@ -2296,7 +2296,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Pain </h2>
-                            <img src="https://fictionhorizon.com/wp-content/uploads/2021/09/pain-quotes.jpg" alt=Pain
+                            <img src="https://fictionhorizon.com/wp-content/uploads/2021/09/pain-quotes.jpg" alt="Pain"
                                 height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2365,7 +2365,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Jūzō Biwa</h2>
 
-                            <img src="./Images/J3F_Biwa.png" alt="Nekobaa" height="300px" width="300px">
+                            <img src="./Images/J3F_Biwa.png" alt="Jūzō Biwa" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <div class="card-body">
@@ -2409,7 +2409,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Rasa</h2>
                             <img src="Images\Rasa.jpg"
-                                alt='Rasa' height="300px" width="300px">
+                                alt="Rasa" height="300px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Rasa (羅砂, Rasa) was the Fourth Kazekage (四代目風影, Yondaime Kazekage, literally meaning: Fourth Wind Shadow) of Sunagakure. Renowned for his ability to use Gold Dust, Rasa's reign as Kazekage was marked by his frequent quelling of rampages by the One-Tailed Shukaku, which he had sealed into his youngest son, Gaara.Rasa was a very powerful shinobi, as evidenced by his title of Kazekage. He could even subdue a fully released tailed beast like Shukaku. The prospect of his retaliation was enough to keep a great group of Iwa-nin from sparking a conflict at the Land of Wind's border.He was shown to be quite observant, pinpointing Gaara's Third Eye that was spying on him and the other reincarnated Kage after Mū sensed his chakra. </p>


### PR DESCRIPTION
Fix issue #994

Solution:
- The text of the `alt` attribute must be between simple quotes
- Add the same name of the title to the description image
- Add uppercase to the first letter of the character name