### PR TITLE
Fixed: Some Images coming out of the Card

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title ">Naruto Uzumaki</h2>
-                            <img data-src="./Images/naruto.png" alt="Naruto" height="330px" width="300px">
+                            <img data-src="./Images/naruto.png" alt="Naruto" height="260px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Naruto Uzumaki is the main protagonist in the popular manga and anime
@@ -312,7 +312,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Naruto Uzumaki</h2>
-                            <img data-src="https://comicvine.gamespot.com/a/uploads/square_small/11117/111178336/5603895-dcc2d502-6c35-49c9-c93c-6eae7f44d551.jpg" alt="Black Zetsu" height="300px" width="300px">
+                            <img data-src="https://comicvine.gamespot.com/a/uploads/square_small/11117/111178336/5603895-dcc2d502-6c35-49c9-c93c-6eae7f44d551.jpg" alt="Black Zetsu" height="280px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Naruto Uzumaki is a hyperactive ninja of the Hidden Leaf Village and a member of Team 7, son of the Fourth Hokage and Kushina Uzumaki. Shortly after his birth, the Nine-Tailed Fox was sealed inside of him, but this was kept a secret from him for years. He has now achieved his dreams and became Konoha's Seventh Hokage. He also has a wife (Hinata) and two children (Himawari and Boruto).</p>
@@ -390,7 +390,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Princess Kasumi</h2>
-                            <img data-src="./Images/Princess_kasumi.jpg" alt="Princess Kasumi" height="350px" width="250px">
+                            <img data-src="./Images/Princess_kasumi.jpg" alt="Princess Kasumi" height="280px" width="250px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kasumi (かすみ, Kasumi) or Princess Dusk (キリ姫, Kiri-hime) The main antagonist of Naruto: Ultimate Ninja Heroes 2. She thirsts for revenge against Konoha Village, but her anger is amplified by Orochimaru's manipulation.</p>
@@ -501,7 +501,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ten Tails - Juubi</h2>
-                            <img data-src="./Images/ten tails.jpeg" alt="Ten Tails - Juubi" height="300px"
+                            <img data-src="./Images/ten tails.jpeg" alt="Ten Tails - Juubi" height="270px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1029,7 +1029,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Madara Uchiha</h2>
-                            <img data-src="Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="300px" width="300px">
+                            <img data-src="Images/madara-uchiha.jpeg" alt="Madara Uchiha" height="270px" width="300px">
                         </div>
                         <div class="flip-card-back">
 
@@ -1339,7 +1339,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Nagato Uzumaki</h2>
 
-                            <img data-src="./Images/nagato.png" alt="Nagato Uzumaki" height="350px" width="380px">
+                            <img data-src="./Images/nagato.png" alt="Nagato Uzumaki" height="320px" width="380px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Nagato was known primarily under the alias of Pain. Nagato is the
@@ -1388,7 +1388,7 @@
                             <h2 class="card-title">Hashirama Senju </h2>
 
                             <img data-src="https://www.giantbomb.com/a/uploads/scale_small/3/33873/1727699-first_hokage.jpg"
-                                alt="Hashirama Senju" height="300px" width="300px">
+                                alt="Hashirama Senju" height="270px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">The First hokage, leader of the Senju clan, one of the founders of
@@ -1632,7 +1632,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Sakon and Ukon</h2>
 
-                            <img data-src="./Images/sakon_ukon.jpg" alt="Sakon and Ukon" height="350px" width="250px">
+                            <img data-src="./Images/sakon_ukon.jpg" alt="Sakon and Ukon" height="280px" width="250px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">
@@ -1727,7 +1727,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Asuma Sarutobi</h2>
 
-                            <img data-src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
+                            <img data-src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="280px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -1781,7 +1781,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kakashi Hatake</h2>
 
-                            <img data-src="./Images/kakashi.jpg" alt="Kakashi Hatake" height="300px" width="300px">
+                            <img data-src="./Images/kakashi.jpg" alt="Kakashi Hatake" height="280px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kakashi Hatake is one of the higher level Ninjas in the hiddenleaf
@@ -2123,7 +2123,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Tobirama Senju</h2>
 
-                            <img data-src="./Images/tobirama senju.png" alt="Tobirama Senju" height="300px"
+                            <img data-src="./Images/tobirama senju.png" alt="Tobirama Senju" height="280px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2198,7 +2198,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Asuma Sarutobi</h2>
 
-                            <img data-src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="300px"
+                            <img data-src="./Images/322897-asuma_sarutobi.jpg" alt="Asuma Sarutobi" height="280px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2282,7 +2282,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Hashirama Senju</h2>
 
-                            <img data-src="./Images/hashirama.jpg" alt="Hashirama Senju" height="300px" width="300px">
+                            <img data-src="./Images/hashirama.jpg" alt="Hashirama Senju" height="280px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">The First hokage, leader of the Senju clan, one of the founders of
@@ -2301,7 +2301,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kaguya Otsutsuki</h2>
 
-                            <img data-src="./Images/Kaguya_Ōtsutsuki.png" alt="Kaguya Otsutsuki" height="300px"
+                            <img data-src="./Images/Kaguya_Ōtsutsuki.png" alt="Kaguya Otsutsuki" height="270px"
                                 width="300px">
                         </div>
                         <div class="flip-card-back">
@@ -2346,7 +2346,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Kisame Hoshigaki</h2>
-                            <img src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="300px" width="300px">
+                            <img src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="270px" width="300px">
                         </div>
                         <div class="flip-card-back">
                             <p class="card-text">Kisame Hoshigaki (干柿 鬼鮫, Hoshigaki Kisame) is a former ninja of Kirigakure and partnered to Itachi Uchiha, having a unique appearance with pale blue skin, a gill-like facial structure, and sharp acute angled triangle teeth. </p>
@@ -2772,7 +2772,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Kisame Hoshigaki</h2>
-                            <img data-src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="300px" width="300px"
+                            <img data-src="./Images/kisame.jpg" alt="Kisame Hoshigaki" height="270px" width="300px"
                                 class="img_card">
                         </div>
                         <div class="flip-card-back">
@@ -2973,7 +2973,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">A Second Raikage</h2>
-                            <img data-src="Images/2nd_Raikage.webp" alt="A (Second Raikage)" height="300px"
+                            <img data-src="Images/2nd_Raikage.webp" alt="A (Second Raikage)" height="270px"
                                 width="300px" class="img_card">
                         </div>
                         <div class="flip-card-back">
@@ -3002,7 +3002,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">A Third Raikage</h2>
-                            <img data-src="Images/Raikage3.webp" alt="A (Third Raikage)" height="300px" width="300px"
+                            <img data-src="Images/Raikage3.webp" alt="A (Third Raikage)" height="270px" width="300px"
                                 class="img_card">
                         </div>
                         <div class="flip-card-back">
@@ -3060,7 +3060,7 @@
                     <div class="flip-card-inner">
                         <div class="flip-card-front">
                             <h2 class="card-title">Ichiraku Ramen</h2>
-                            <img data-src="Images/ichiraku-ramen.jpeg" alt="Ichiraku Ramen" height="300px" width="300px"
+                            <img data-src="Images/ichiraku-ramen.jpeg" alt="Ichiraku Ramen" height="270px" width="300px"
                                 class="img_card">
                         </div>
                         <div class="flip-card-back">
@@ -3266,7 +3266,7 @@
                         <div class="flip-card-front">
                             <h2 class="card-title">Kabuto Yakushi</h2>
 
-                            <img src="./Images/Kabuto_Yakushi.png" alt="Kabuto Yakushi" height="300px" width="300px">
+                            <img src="./Images/Kabuto_Yakushi.png" alt="Kabuto Yakushi" height="270px" width="300px">
                         </div>
                         <div class="flip-card-back">
 


### PR DESCRIPTION
Solves issue #1118 

Fixed the issue of images coming out the card for all the </b>distorted cards</b>

## Some Edited screenshots:

<img width="939" alt="Screenshot 2023-10-20 230230" src="https://github.com/vikhyatsingh123/Naruto-Shippuden/assets/96042938/0fce86b4-953c-43a5-87cc-c45427a8addf">
<img width="899" alt="Screenshot 2023-10-20 230214" src="https://github.com/vikhyatsingh123/Naruto-Shippuden/assets/96042938/44c8a00d-5d17-4308-9361-df28b4accd72">

## Some Original:
<img width="957" alt="Screenshot 2023-10-19 201405" src="https://github.com/vikhyatsingh123/Naruto-Shippuden/assets/96042938/2cba087e-f2b6-4f65-b940-8f1530851640">
<img width="942" alt="Screenshot 2023-10-20 224049" src="https://github.com/vikhyatsingh123/Naruto-Shippuden/assets/96042938/1e9df88a-4613-4be6-8551-d10b4efca144">

## Note: All images like these have been corrected and positioned.
